### PR TITLE
TPRUN-4138 Supporting camel-google-pubsub and camel-grpc OSGi deployment

### DIFF
--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -971,6 +971,48 @@
     <bundle dependency='true'>mvn:com.google.guava/guava/${google-mail-guava-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-google-mail/${upstream.version}</bundle>
   </feature>
+  <feature name='camel-google-pubsub' version='${upstream.version}' start-level='50'>
+    <feature version='${upstream.version}'>camel-core</feature>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.google-cloud-pubsub/${google-cloud-pubsub-bundle-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.google.api/api-common/${google-pubsub-google-cloud-api-common-version}</bundle>
+    <bundle dependency='true'>mvn:com.google.protobuf/protobuf-java/${google-common-protobuf-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.google.api.grpc/proto-google-common-protos/${google-common-google-cloud-common-protos-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.google.api.grpc/proto-google-iam-v1/${google-proto-iam-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.guava/${google-cloud-guava-bundle-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.google-gax-grpc/${google-gax-bundle-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.google.auth/google-auth-library-oauth2-http/${grpc-google-auth-library-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.google.auth/google-auth-library-credentials/${grpc-google-auth-library-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:org.threeten/threetenbp/${google-pubsub-google-cloud-threetenbp-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:io.opencensus/opencensus-api/${google-http-client-opencensus-api-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.google.code.gson/gson/${google-common-gson-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:io.perfmark/perfmark-api/${google-cloud-perfmark-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.google-http-client/${google-http-client-bundle-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:io.opencensus/opencensus-contrib-http-util/${google-http-client-opencensus-api-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.httpcomponents/httpcore-osgi/${httpcore4-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.httpcomponents/httpclient-osgi/${httpclient4-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.grpc/${google-cloud-grpc-bundle-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.google.re2j/re2j/${re2j-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-common/${google-common-netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-codec/${google-common-netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-codec-http/${google-common-netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-codec-http2/${google-common-netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-codec-socks/${google-common-netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-resolver/${google-common-netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-transport/${google-common-netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-buffer/${google-common-netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-transport-classes-epoll/${google-common-netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-transport-native-unix-common/${google-common-netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-handler/${google-common-netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-handler-proxy/${google-common-netty-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:io.opencensus/opencensus-proto/${opencensus-proto-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okhttp/${squareup-okhttp-bundle-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okio/${squareup-okio-bundle-version}</bundle>
+    <bundle dependency='true'>mvn:org.bouncycastle/bcpkix-jdk18on/${google-common-bouncycastle-version}</bundle>
+    <bundle dependency='true'>mvn:org.bouncycastle/bctls-jdk18on/${google-common-bouncycastle-version}</bundle>
+    <bundle dependency='true'>mvn:org.bouncycastle/bcprov-jdk18on/${google-common-bouncycastle-version}</bundle>
+    <bundle dependency='true'>mvn:org.bouncycastle/bcutil-jdk18on/${google-common-bouncycastle-version}</bundle>
+    <bundle>mvn:org.apache.camel/camel-google-pubsub/${upstream.version}</bundle>
+  </feature>
   <feature name='camel-grape' version='${upstream.version}' start-level='50'>
     <feature version='${upstream.version}'>camel-core</feature>
     <bundle dependency='true'>mvn:org.codehaus.groovy/groovy/${groovy-version}</bundle>
@@ -1015,7 +1057,42 @@
     <bundle dependency='true'>wrap:mvn:io.krakens/java-grok/${java-grok-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-grok/${upstream.version}</bundle>
   </feature>
-
+  <feature name='camel-grpc' version='${upstream.version}' start-level='50'>
+    <feature version='${upstream.version}'>camel-core</feature>
+    <bundle dependency='true'>wrap:mvn:com.auth0/java-jwt/${grpc-java-jwt-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.google.auth/google-auth-library-oauth2-http/${grpc-google-auth-library-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.google.auth/google-auth-library-credentials/${grpc-google-auth-library-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.grpc/${google-cloud-grpc-bundle-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.guava/${google-cloud-guava-bundle-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.google.api.grpc/proto-google-common-protos/${google-common-google-cloud-common-protos-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.google.code.gson/gson/${google-common-gson-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.google.re2j/re2j/${re2j-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okhttp/${squareup-okhttp-bundle-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-transport/${google-common-netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-buffer/${google-common-netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-common/${google-common-netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-resolver/${google-common-netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-transport-classes-epoll/${google-common-netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-transport-native-unix-common/${google-common-netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-codec/${google-common-netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-codec-http/${google-common-netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-codec-http2/${google-common-netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-handler/${google-common-netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-handler-proxy/${google-common-netty-version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-codec-socks/${google-common-netty-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:io.opencensus/opencensus-api/${google-http-client-opencensus-api-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:io.opencensus/opencensus-proto/${opencensus-proto-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:io.perfmark/perfmark-api/${google-cloud-perfmark-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okio/${squareup-okio-bundle-version}</bundle>
+    <bundle dependency='true'>mvn:org.bouncycastle/bcprov-jdk18on/${google-common-bouncycastle-version}</bundle>
+    <bundle dependency='true'>mvn:org.bouncycastle/bcpkix-jdk18on/${google-common-bouncycastle-version}</bundle>
+    <bundle dependency='true'>mvn:org.bouncycastle/bcutil-jdk18on/${google-common-bouncycastle-version}</bundle>
+    <bundle dependency='true'>mvn:org.bouncycastle/bctls-jdk18on/${google-common-bouncycastle-version}</bundle>
+    <bundle dependency='true'>mvn:org.javassist/javassist/${grpc-javassist-version}</bundle>
+    <bundle dependency='true'>mvn:com.google.protobuf/protobuf-java/${google-common-protobuf-version}</bundle>
+    <bundle dependency='true'>mvn:com.google.protobuf/protobuf-java-util/${google-common-protobuf-version}</bundle>
+    <bundle>mvn:org.apache.camel/camel-grpc/${upstream.version}</bundle>
+  </feature>
 
   <feature name='camel-gson' version='${upstream.version}' start-level='50'>
     <feature version='${upstream.version}'>camel-core</feature>

--- a/pom.xml
+++ b/pom.xml
@@ -202,17 +202,41 @@
         <google-cloud-core-version>1.93.10</google-cloud-core-version>
         <google-cloud-gax-version>1.60.0</google-cloud-gax-version>
         <google-cloud-gax-httpjson-version>0.77.0</google-cloud-gax-httpjson-version>
+        <google-cloud-grpc-bundle-version>1.48.1_2</google-cloud-grpc-bundle-version>
+        <google-cloud-guava-bundle-version>31.1_1</google-cloud-guava-bundle-version>
         <google-cloud-http-client-version>1.38.0</google-cloud-http-client-version>
         <google-cloud-oauth-client-version>1.31.1</google-cloud-oauth-client-version>
         <google-cloud-common-protos-version>2.0.1</google-cloud-common-protos-version>
+        <google-cloud-perfmark-version>0.25.0</google-cloud-perfmark-version>
+        <google-cloud-pubsub-bundle-version>1.119.0_1</google-cloud-pubsub-bundle-version>
         <google-cloud-iam-version>1.0.3</google-cloud-iam-version>
         <google-cloud-threetenbp-version>1.5.0</google-cloud-threetenbp-version>
+        <!-- Start common versions for google pubsub and grpc-->
+        <google-common-bouncycastle-version>1.71</google-common-bouncycastle-version>
+        <google-common-google-cloud-common-protos-version>2.8.3</google-common-google-cloud-common-protos-version>
+        <google-common-gson-version>2.9.1</google-common-gson-version>
+        <google-common-netty-version>4.1.79.Final</google-common-netty-version>
+        <google-common-protobuf-version>3.21.4</google-common-protobuf-version>
+        <!-- End common versions for google pubsub and grpc-->
         <google-findbugs-jsr305-version>3.0.2</google-findbugs-jsr305-version>
         <google-findbugs-annotations2-version>2.0.3</google-findbugs-annotations2-version>
+        <google-gax-bundle-version>2.18.1_1</google-gax-bundle-version>
+        <google-http-client-bundle-version>1.41.8_2</google-http-client-bundle-version>
+        <google-http-client-opencensus-api-version>0.31.1</google-http-client-opencensus-api-version>
+        <google-proto-iam-version>1.3.4</google-proto-iam-version>
+        <!-- Start specific versions for google pubsub-->
+        <google-pubsub-google-cloud-api-common-version>2.2.0</google-pubsub-google-cloud-api-common-version>
+        <google-pubsub-google-cloud-common-protos-version>2.8.3</google-pubsub-google-cloud-common-protos-version>
+        <google-pubsub-google-cloud-threetenbp-version>1.6.0</google-pubsub-google-cloud-threetenbp-version>
+        <!-- End specific versions for google pubsub-->
         <google-truth-version>0.30</google-truth-version>
         <groovy-version>3.0.8</groovy-version>
+        <!-- Start specific versions for grpc-->
+        <grpc-javassist-version>3.28.0-GA</grpc-javassist-version>
+        <!-- End specific versions for grpc-->
         <grpc-bundle-version>1.38.0_1</grpc-bundle-version>
         <grpc-errorprone-version>2.3.4</grpc-errorprone-version>
+        <grpc-google-auth-library-version>1.7.0</grpc-google-auth-library-version>
         <guice-bundle-version>3.0_1</guice-bundle-version>
         <hikaricp-version>2.4.13</hikaricp-version>
         <hk2-osgi-resource-version>1.0.1</hk2-osgi-resource-version>
@@ -266,6 +290,7 @@
         <olingo2-gson-version>2.4</olingo2-gson-version>
         <ognl-bundle-version>3.1.12_1</ognl-bundle-version>
         <opencensus-api-version>0.24.0</opencensus-api-version>
+        <opencensus-proto-version>0.2.0</opencensus-proto-version>
         <oncrpc-version>1.1.3</oncrpc-version>
         <ops4j-base-version>1.5.0</ops4j-base-version>
         <oro-bundle-version>2.0.8_6</oro-bundle-version>
@@ -281,6 +306,7 @@
         <reflections-bundle-version>0.9.12_1</reflections-bundle-version>
         <regexp-bundle-version>1.4_1</regexp-bundle-version>
         <roaster-version>2.21.1.Final</roaster-version>
+        <re2j-version>1.5</re2j-version>
         <saxon-bundle-version>9.9.1-6_1</saxon-bundle-version>
         <scribe-bundle-version>1.3.7_1</scribe-bundle-version>
         <serp-bundle-version>1.14.1_1</serp-bundle-version>


### PR DESCRIPTION
Fix for https://jira.talendforge.org/browse/TPRUN-4138

## Motivation

There is no `camel-google-pubsub` and `camel-grpc` karaf features available anymore with Camel 3. It would be nice to have OSGi-ready features back for this version.

It has been fixed in Apache Camel/Camel Karaf in 3.18.2 (cf https://issues.apache.org/jira/browse/CAMEL-18344) but we would need a backport in our internal branch.

## Modifications

* Add the missing features
* Ensure that the versions used are only scoped to those specific components