### PR TITLE
fix(TPRUN-4497) fix camel sprint redis startup

### DIFF
--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -1720,6 +1720,7 @@
     <bundle dependency='true'>mvn:io.netty/netty-buffer/${netty.tesb.version}</bundle>
     <bundle dependency='true'>mvn:io.netty/netty-transport/${netty.tesb.version}</bundle>
     <bundle dependency='true'>mvn:io.netty/netty-handler/${netty.tesb.version}</bundle>
+    <bundle dependency='true'>mvn:io.netty/netty-transport-classes-epoll/${netty.tesb.version}</bundle>
     <bundle dependency='true'>mvn:io.netty/netty-transport-native-epoll/${netty.tesb.version}</bundle>
     <bundle dependency='true'>mvn:io.netty/netty-transport-native-unix-common/${netty.tesb.version}</bundle>
     <bundle dependency='true'>mvn:io.netty/netty-codec/${netty.tesb.version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
 
     <properties>
         <upstream.version>3.11.1</upstream.version>
-        <camel.features.tesb.version>3.11.1.20221020</camel.features.tesb.version>
+        <camel.features.tesb.version>3.11.1.20221125</camel.features.tesb.version>
         <jaxb-bundle-version.tesb.version>2.3.2_1</jaxb-bundle-version.tesb.version>
         <woodstox-version.tesb.version>6.2.6</woodstox-version.tesb.version>
         <activemq-version.tesb.version>5.16.4</activemq-version.tesb.version>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
camel sprint redis feature does not start

**What is the chosen solution to this problem?**
Add missing dependency to the camel netty feature
mvn:io.netty/netty-transport-classes-epoll

**Impacts**

- [ ] **This PR introduces a breaking change**

* **components**

 
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TPRUN-4497

Close detail ( T )
 
**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->