### PR TITLE
TPRUN-5600 TPRUN-5629 TPRUN-5630 Updates of vulnerable dependencies.

### DIFF
--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -1397,8 +1397,8 @@
     <feature version='${upstream.version}'>camel-core</feature>
     <!-- json-path 2.5 and 2.6 does not work with OSGi -->
     <bundle>mvn:com.jayway.jsonpath/json-path/2.4.0</bundle>
-    <bundle dependency='true'>mvn:net.minidev/json-smart/${json-smart-version}</bundle>
-    <bundle dependency='true'>mvn:net.minidev/accessors-smart/${json-smart-version}</bundle>
+    <bundle dependency='true'>mvn:net.minidev/json-smart/${json-smart.tesb.version}</bundle>
+    <bundle dependency='true'>mvn:net.minidev/accessors-smart/${json-smart.tesb.version}</bundle>
     <bundle dependency='true'>mvn:org.ow2.asm/asm/${asm.bundle.version}</bundle>
     <bundle dependency='true'>mvn:org.ow2.asm/asm-analysis/${asm.bundle.version}</bundle>
     <bundle dependency='true'>mvn:org.ow2.asm/asm-commons/${asm.bundle.version}</bundle>
@@ -2003,7 +2003,7 @@
     <bundle dependency='true'>mvn:com.fasterxml.jackson.datatype/jackson-datatype-jsr310/${jackson2.tesb.version}</bundle>
     <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3-version}</bundle>
     <bundle dependency='true'>mvn:javax.validation/validation-api/${validation-1-api-version}</bundle>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/${xstream-bundle-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/${xstream-bundle.tesb.version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xpp3/${xpp3-bundle-version}</bundle>
     <bundle dependency='true'>mvn:javax.servlet/javax.servlet-api/${javax-servlet-api-version}</bundle>
     <bundle dependency='true'>mvn:org.cometd.java/cometd-java-client/${cometd-java-client-version}</bundle>
@@ -2563,7 +2563,7 @@
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xpp3/${xpp3-bundle-version}</bundle>
     <bundle dependency='true'>mvn:joda-time/joda-time/${jodatime-bundle-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.kxml2/${kxml2-bundle-version}</bundle>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/${xstream-bundle-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/${xstream-bundle.tesb.version}</bundle>
     <bundle>mvn:org.apache.camel/camel-xstream/${upstream.version}</bundle>
   </feature>
   <feature name='camel-yaml-dsl' version='${upstream.version}' start-level='50'>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
 
     <properties>
         <upstream.version>3.11.1</upstream.version>
-        <camel.features.tesb.version>3.11.1.20230324</camel.features.tesb.version>
+        <camel.features.tesb.version>3.11.1.20230330</camel.features.tesb.version>
         <jaxb-bundle-version.tesb.version>2.3.2_1</jaxb-bundle-version.tesb.version>
         <woodstox-version.tesb.version>6.4.0</woodstox-version.tesb.version>
         <activemq-version.tesb.version>5.16.4</activemq-version.tesb.version>
@@ -124,14 +124,16 @@
         <avro-jackson-databind.tesb.version>2.14.1</avro-jackson-databind.tesb.version>
         <servicemix.avro.tesb.version>1.11.1_1.tesb1</servicemix.avro.tesb.version>
         <braintree-jackson2.tesb.version>2.14.1</braintree-jackson2.tesb.version>
+        <json-smart.tesb.version>2.4.9</json-smart.tesb.version>
         <json-validator-jackson.tesb.version>2.14.1</json-validator-jackson.tesb.version>
         <json-validator-jackson-databind.tesb.version>2.14.1</json-validator-jackson-databind.tesb.version>
         <snakeyaml.tesb.version>1.33</snakeyaml.tesb.version>
-        <jettison.tesb.version>1.5.3</jettison.tesb.version>
+        <jettison.tesb.version>1.5.4</jettison.tesb.version>
         <tika.tesb.version>1.28.4</tika.tesb.version>
         <commons-text.tesb.version>1.10.0</commons-text.tesb.version>
         <kafka-bundle.tesb.version>2.8.2_1</kafka-bundle.tesb.version>
         <sshd.tesb.version>2.9.2</sshd.tesb.version>
+        <xstream-bundle.tesb.version>1.4.20_1</xstream-bundle.tesb.version>
         <spring.tesb.version-range>[5.2,6)</spring.tesb.version-range>
 
         <!-- unify the encoding for all the modules -->
@@ -598,6 +600,7 @@
                             <avro-jackson.tesb.version>${avro-jackson.tesb.version}</avro-jackson.tesb.version>
                             <avro-jackson-databind.tesb.version>${avro-jackson-databind.tesb.version}</avro-jackson-databind.tesb.version>
                             <braintree-jackson2.tesb.version>${braintree-jackson2.tesb.version}</braintree-jackson2.tesb.version>
+                            <json-smart.tesb.version>${json-smart.tesb.version}</json-smart.tesb.version>
                             <json-validator-jackson.tesb.version>${json-validator-jackson.tesb.version}</json-validator-jackson.tesb.version>
                             <json-validator-jackson-databind.tesb.version>${json-validator-jackson-databind.tesb.version}</json-validator-jackson-databind.tesb.version>
                             <snakeyaml.tesb.version>${snakeyaml.tesb.version}</snakeyaml.tesb.version>
@@ -605,6 +608,7 @@
                             <tika.tesb.version>${tika.tesb.version}</tika.tesb.version>
                             <commons-text.tesb.version>${commons-text.tesb.version}</commons-text.tesb.version>
                             <kafka-bundle.tesb.version>${kafka-bundle.tesb.version}</kafka-bundle.tesb.version>
+                            <xstream-bundle.tesb.version>${xstream-bundle.tesb.version}</xstream-bundle.tesb.version>
                             <sshd.tesb.version>${sshd.tesb.version}</sshd.tesb.version>
                             <spring.tesb.version-range>${spring.tesb.version-range}</spring.tesb.version-range>
                         </properties>


### PR DESCRIPTION
CVE-2022-41966 Xstream to 1.4.20
CVE-2023-1430 Jettison to 1.5.4
CVE-2023-1370 json-smart to 2.4.9