### PR TITLE
fix(TPRUN-6049) guava .createTempDir() vulnerability | CVE-2020-8908

### DIFF
--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -236,8 +236,8 @@
     <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-databind/${avro-jackson-databind.tesb.version}</bundle>
     <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-annotations/${avro-jackson.tesb.version}</bundle>
     <bundle dependency='true'>mvn:org.apache.commons/commons-compress/${avro-java-commons-compress-version}</bundle>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.avro/${servicemix.avro.version}</bundle>
-    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.paranamer/${servicemix.paranamer.version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.avro/${avro-bundle-version}</bundle>
+    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.paranamer/${paranamer-bundle-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-avro/${upstream.version}</bundle>
   </feature>
   <feature name='camel-aws2-athena' version='${upstream.version}' start-level='50'>
@@ -1223,8 +1223,8 @@
   <feature name='camel-jackson-avro' version='${upstream.version}' start-level='50'>
     <feature version='${upstream.version}'>camel-jackson</feature>
     <bundle dependency='true'>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-avro/${jackson2.tesb.version}</bundle>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.avro/${servicemix.avro.version}</bundle>
-    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.paranamer/${servicemix.paranamer.version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.avro/${avro-bundle-version}</bundle>
+    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.paranamer/${paranamer-bundle-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.commons/commons-compress/${avro-java-commons-compress-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-jackson-avro/${upstream.version}</bundle>
   </feature>

--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -1879,10 +1879,11 @@
   </feature>
   <feature name='camel-protobuf' version='${upstream.version}' start-level='50'>
     <feature version='${upstream.version}'>camel-core</feature>
-    <bundle dependency='true'>mvn:com.google.protobuf/protobuf-java/${protobuf-version}</bundle>
-    <bundle dependency='true'>mvn:com.google.protobuf/protobuf-java-util/${protobuf-version}</bundle>
+    <bundle dependency='true'>mvn:com.google.protobuf/protobuf-java/${google.protobuf.tesb.version}</bundle>
+    <bundle dependency='true'>mvn:com.google.protobuf/protobuf-java-util/${google.protobuf-util.tesb.version}</bundle>
+    <bundle dependency='true'>mvn:com.google.code.findbugs/jsr305/${google-findbugs-jsr305-version}</bundle>
     <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io-version}</bundle>
-    <bundle dependency='true'>mvn:com.google.guava/guava/${protobuf-guava-version}</bundle>
+    <bundle dependency='true'>mvn:com.google.guava/guava/${google.guava.tesb.version}</bundle>
     <bundle dependency='true'>mvn:com.google.code.gson/gson/${gson-version}</bundle>
     <bundle dependency='true'>mvn:com.google.guava/failureaccess/1.0.1</bundle>
     <bundle>mvn:org.apache.camel/camel-protobuf/${upstream.version}</bundle>

--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -1419,7 +1419,8 @@
   </feature>
   <feature name='camel-kafka' version='${upstream.version}' start-level='50'>
     <feature version='${upstream.version}'>camel-core</feature>
-    <feature version='${upstream.version}'>camel-avro</feature>
+    <!-- TPRUN-5903 is on hold -->
+    <!-- <feature version='${upstream.version}'>camel-avro</feature> -->
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.kafka-clients/${kafka-bundle.tesb.version}</bundle>
     <bundle dependency='true'>mvn:org.xerial.snappy/snappy-java/${snappy-version}</bundle>
     <bundle dependency='true'>wrap:mvn:org.lz4/lz4-java/${lz4-version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
 
     <properties>
         <upstream.version>3.11.1</upstream.version>
-        <camel.features.tesb.version>3.11.1.20230525</camel.features.tesb.version>
+        <camel.features.tesb.version>3.11.1.20230627</camel.features.tesb.version>
         <jaxb-bundle-version.tesb.version>2.3.2_1</jaxb-bundle-version.tesb.version>
         <woodstox-version.tesb.version>6.4.0</woodstox-version.tesb.version>
         <activemq-version.tesb.version>5.16.4</activemq-version.tesb.version>
@@ -136,7 +136,10 @@
         <xstream-bundle.tesb.version>1.4.20_1</xstream-bundle.tesb.version>
         <shiro.tesb.version>1.11.0</shiro.tesb.version>
         <spring.tesb.version-range>[5.2,6)</spring.tesb.version-range>
-
+        <google.protobuf-util.tesb.version>3.23.3</google.protobuf-util.tesb.version>
+        <google.protobuf.tesb.version>3.23.3</google.protobuf.tesb.version>
+        <google.guava.tesb.version>32.0.1-jre</google.guava.tesb.version>
+		
         <!-- unify the encoding for all the modules -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,9 @@
         <tika.tesb.version>1.28.4</tika.tesb.version>
         <commons-text.tesb.version>1.10.0</commons-text.tesb.version>
         <commons-net.tesb.version>3.9.0</commons-net.tesb.version>
-        <kafka-bundle.tesb.version>2.8.2_1-tesb3</kafka-bundle.tesb.version>
+        <!-- on hold TPRUN-5432  -->
+        <!-- <kafka-bundle.tesb.version>2.8.2_1-tesb3</kafka-bundle.tesb.version> -->
+        <kafka-bundle.tesb.version>2.8.2_1</kafka-bundle.tesb.version>
         <sshd.tesb.version>2.9.2</sshd.tesb.version>
         <xstream-bundle.tesb.version>1.4.20_1</xstream-bundle.tesb.version>
         <shiro.tesb.version>1.11.0</shiro.tesb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <tika.tesb.version>1.28.4</tika.tesb.version>
         <commons-text.tesb.version>1.10.0</commons-text.tesb.version>
         <commons-net.tesb.version>3.9.0</commons-net.tesb.version>
-        <!-- on hold TPRUN-5432  -->
+        <!-- TPRUN-5432 is on hold -->
         <!-- <kafka-bundle.tesb.version>2.8.2_1-tesb3</kafka-bundle.tesb.version> -->
         <kafka-bundle.tesb.version>2.8.2_1</kafka-bundle.tesb.version>
         <sshd.tesb.version>2.9.2</sshd.tesb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -309,6 +309,7 @@
         <ops4j-base-version>1.5.0</ops4j-base-version>
         <oro-bundle-version>2.0.8_6</oro-bundle-version>
         <osgi-version>6.0.0</osgi-version>
+        <avro-bundle-version>1.11.1_1</avro-bundle-version>
         <paranamer-bundle-version>2.8_1</paranamer-bundle-version>
         <pax-cdi-version>1.0.0</pax-cdi-version>
         <pax-exam-version>4.13.4</pax-exam-version>


### PR DESCRIPTION
🏁 **Context**
- [TPRUN-6049](https://jira.talendforge.org/browse/TPRUN-6049)
- Fix in release notes: https://github.com/google/guava/releases

🔍 **What is the problem this PR is trying to solve?**
In Guava 30, the .createTempDir() method was declared as deprecated without addressing the vulnerability (it was only rectified in the latest release, 32.0.1-jre). Currently, some databases still identify Guava 30 as a CVE.

🚀 **What is the chosen solution to this problem?**
Bump-up guava version

🎾 **Impacts**

- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR