### PR TITLE
fix(DPE-420) : remove usage of aws servicemix

### DIFF
--- a/platforms/karaf/features/pom.xml
+++ b/platforms/karaf/features/pom.xml
@@ -35,6 +35,8 @@
     <properties>
         <revision>${camel.features.tesb.version}</revision>
         <features.file>features.xml</features.file>
+        <spi-consumer>SPI-Consumer=*</spi-consumer>
+        <spi-provider>SPI-Provider=*</spi-provider>
     </properties>
 
     <!-- The validate plugin will export these provided dependencies bundles export packages first -->

--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -33,6 +33,34 @@
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-runtime/${jaxb-bundle.tesb.version}</bundle>
   </feature>
 
+  <feature name="awssdk" version="${aws-java-sdk2-version}" start-level="50">
+    <bundle dependency='true'>mvn:org.apache.httpcomponents/httpcore-osgi/${httpcore4.tesb.version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.httpcomponents/httpclient-osgi/${httpclient4.tesb.version}</bundle>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/auth/${aws-java-sdk2-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/aws-core/${aws-java-sdk2-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/sdk-core/${aws-java-sdk2-version}$${spi-consumer}</bundle>
+<!--    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/retries-spi/${aws-java-sdk2-version}</bundle>-->
+<!--    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/retries/${aws-java-sdk2-version}</bundle>-->
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/http-client-spi/${aws-java-sdk2-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/apache-client/${aws-java-sdk2-version}$${spi-provider}</bundle>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/regions/${aws-java-sdk2-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/utils/${aws-java-sdk2-version}</bundle>
+<!--    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/identity-spi/${aws-java-sdk2-version}</bundle>-->
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/profiles/${aws-java-sdk2-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/endpoints-spi/${aws-java-sdk2-version}</bundle>
+<!--    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/http-auth-spi/${aws-java-sdk2-version}</bundle>-->
+<!--    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/http-auth-aws/${aws-java-sdk2-version}</bundle>-->
+<!--    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/http-auth/${aws-java-sdk2-version}</bundle>-->
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/metrics-spi/${aws-java-sdk2-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/aws-query-protocol/${aws-java-sdk2-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/protocol-core/${aws-java-sdk2-version}</bundle>
+<!--    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/checksums/${aws-java-sdk2-version}</bundle>-->
+<!--    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/checksums-spi/${aws-java-sdk2-version}</bundle>-->
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/json-utils/${aws-java-sdk2-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/third-party-jackson-core/${aws-java-sdk2-version}</bundle>
+    <bundle dependency='true'>mvn:org.reactivestreams/reactive-streams/${reactive-streams-version}</bundle>
+  </feature>
+
   <feature name='camel' version='${upstream.version}' start-level='50'>
     <feature prerequisite='true'>wrap</feature> <!-- some camel features needs wrap -->
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
@@ -216,116 +244,148 @@
   </feature>
   <feature name='camel-aws2-athena' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.aws-java-sdk2/${aws-sdk-v2-bundle-version}</bundle>
+    <feature version="${aws-java-sdk2-version}">awssdk</feature>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/athena/${aws-java-sdk2-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-aws2-athena/${upstream.version}</bundle>
   </feature>
   <feature name='camel-aws2-cw' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.aws-java-sdk2/${aws-sdk-v2-bundle-version}</bundle>
+    <feature version="${aws-java-sdk2-version}">awssdk</feature>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/cloudwatch/${aws-java-sdk2-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-aws2-cw/${upstream.version}</bundle>
   </feature>
   <feature name='camel-aws2-ddb' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.aws-java-sdk2/${aws-sdk-v2-bundle-version}</bundle>
+    <feature version="${aws-java-sdk2-version}">awssdk</feature>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/dynamodb/${aws-java-sdk2-version}</bundle>
+    <bundle dependency='true'>mvn:com.google.code.gson/gson/${gson-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-aws2-ddb/${upstream.version}</bundle>
   </feature>
   <feature name='camel-aws2-ec2' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.aws-java-sdk2/${aws-sdk-v2-bundle-version}</bundle>
+    <feature version="${aws-java-sdk2-version}">awssdk</feature>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/ec2/${aws-java-sdk2-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-aws2-ec2/${upstream.version}</bundle>
   </feature>
   <feature name='camel-aws2-ecs' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.aws-java-sdk2/${aws-sdk-v2-bundle-version}</bundle>
+    <feature version="${aws-java-sdk2-version}">awssdk</feature>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/ecs/${aws-java-sdk2-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-aws2-ecs/${upstream.version}</bundle>
   </feature>
   <feature name='camel-aws2-eks' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.aws-java-sdk2/${aws-sdk-v2-bundle-version}</bundle>
+    <feature version="${aws-java-sdk2-version}">awssdk</feature>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/eks/${aws-java-sdk2-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/aws-json-protocol/${aws-java-sdk2-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-aws2-eks/${upstream.version}</bundle>
   </feature>
   <feature name='camel-aws2-eventbridge' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
     <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io.tesb.version}</bundle>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.aws-java-sdk2/${aws-sdk-v2-bundle-version}</bundle>
+    <feature version="${aws-java-sdk2-version}">awssdk</feature>
+    <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io.tesb.version}</bundle>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/eventbridge/${aws-java-sdk2-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-aws2-eventbridge/${upstream.version}</bundle>
   </feature>
   <feature name='camel-aws2-iam' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.aws-java-sdk2/${aws-sdk-v2-bundle-version}</bundle>
+    <feature version="${aws-java-sdk2-version}">awssdk</feature>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/iam/${aws-java-sdk2-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-aws2-iam/${upstream.version}</bundle>
   </feature>
   <feature name='camel-aws2-kinesis' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.aws-java-sdk2/${aws-sdk-v2-bundle-version}</bundle>
+    <feature version="${aws-java-sdk2-version}">awssdk</feature>
+    <bundle dependency="true">wrap:mvn:software.amazon.awssdk/netty-nio-client/${aws-java-sdk2-version}</bundle>
+    <bundle dependency="true">wrap:mvn:software.amazon.awssdk/firehose/${aws-java-sdk2-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/kinesis/${aws-java-sdk2-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/dynamodb/${aws-java-sdk2-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/cloudwatch/${aws-java-sdk2-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-aws2-kinesis/${camel-aws.tesb.version}</bundle>
   </feature>
   <feature name='camel-aws2-kms' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.aws-java-sdk2/${aws-sdk-v2-bundle-version}</bundle>
+    <feature version="${aws-java-sdk2-version}">awssdk</feature>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/kms/${aws-java-sdk2-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-aws2-kms/${upstream.version}</bundle>
   </feature>
   <feature name='camel-aws2-lambda' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.aws-java-sdk2/${aws-sdk-v2-bundle-version}</bundle>
+    <feature version="${aws-java-sdk2-version}">awssdk</feature>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/lambda/${aws-java-sdk2-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-aws2-lambda/${upstream.version}</bundle>
   </feature>
   <feature name='camel-aws2-mq' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.aws-java-sdk2/${aws-sdk-v2-bundle-version}</bundle>
+    <feature version="${aws-java-sdk2-version}">awssdk</feature>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/mq/${aws-java-sdk2-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/aws-json-protocol/${aws-java-sdk2-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-aws2-mq/${upstream.version}</bundle>
   </feature>
   <feature name='camel-aws2-msk' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.aws-java-sdk2/${aws-sdk-v2-bundle-version}</bundle>
+    <feature version="${aws-java-sdk2-version}">awssdk</feature>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/kafka/${aws-java-sdk2-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-aws2-msk/${upstream.version}</bundle>
   </feature>
   <feature name='camel-aws2-s3' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.aws-java-sdk2/${aws-sdk-v2-bundle-version}</bundle>
+    <feature version="${aws-java-sdk2-version}">awssdk</feature>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/s3/${aws-java-sdk2-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/aws-xml-protocol/${aws-java-sdk2-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-aws2-s3/${upstream.version}</bundle>
   </feature>
   <feature name='camel-aws2-ses' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.aws-java-sdk2/${aws-sdk-v2-bundle-version}</bundle>
+    <feature version="${aws-java-sdk2-version}">awssdk</feature>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/ses/${aws-java-sdk2-version}</bundle>
     <bundle dependency='true'>mvn:com.sun.mail/jakarta.mail/${jakarta-mail-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-aws2-ses/${upstream.version}</bundle>
   </feature>
   <feature name='camel-aws2-sns' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
+    <feature version="${aws-java-sdk2-version}">awssdk</feature>
     <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io.tesb.version}</bundle>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.aws-java-sdk2/${aws-sdk-v2-bundle-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/sns/${aws-java-sdk2-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-aws2-sns/${upstream.version}</bundle>
   </feature>
   <feature name='camel-aws2-sqs' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
+    <feature version="${aws-java-sdk2-version}">awssdk</feature>
     <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io.tesb.version}</bundle>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.aws-java-sdk2/${aws-sdk-v2-bundle-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/sqs/${aws-java-sdk2-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/aws-json-protocol/${aws-java-sdk2-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-aws2-sqs/${upstream.version}</bundle>
   </feature>
   <feature name='camel-aws2-sts' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.aws-java-sdk2/${aws-sdk-v2-bundle-version}</bundle>
+    <feature version="${aws-java-sdk2-version}">awssdk</feature>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/sts/${aws-java-sdk2-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-aws2-sts/${upstream.version}</bundle>
   </feature>
   <feature name='camel-aws2-translate' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.aws-java-sdk2/${aws-sdk-v2-bundle-version}</bundle>
+    <feature version="${aws-java-sdk2-version}">awssdk</feature>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/translate/${aws-java-sdk2-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-aws2-translate/${upstream.version}</bundle>
   </feature>
   <feature name='camel-aws-secrets-manager' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.aws-java-sdk2/${aws-sdk-v2-bundle-version}</bundle>
+    <feature version="${aws-java-sdk2-version}">awssdk</feature>
     <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-core/${jackson2.tesb.version}</bundle>
     <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2.tesb.version}</bundle>
     <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2.tesb.version}</bundle>
     <bundle dependency='true'>mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-xml/${jackson2.tesb.version}</bundle>
     <bundle dependency='true'>mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${jackson2.tesb.version}</bundle>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/cloudtrail/${aws-java-sdk2-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/secretsmanager/${aws-java-sdk2-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-aws-secrets-manager/${upstream.version}</bundle>
   </feature>
   <feature name='camel-aws-cloudtrail' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
-    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.aws-java-sdk2/${aws-sdk-v2-bundle-version}</bundle>
+    <feature version="${aws-java-sdk2-version}">awssdk</feature>
+    <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/cloudtrail/${aws-java-sdk2-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-aws-cloudtrail/${upstream.version}</bundle>
   </feature>
   <feature name='camel-aws-xray' version='${upstream.version}' start-level='50'>
@@ -350,6 +410,8 @@
     <bundle dependency='true'>mvn:org.reactivestreams/reactive-streams/${reactive-streams-version}</bundle>
     <bundle dependency='true'>mvn:io.projectreactor/reactor-core/${reactor-version}</bundle>
     <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io.tesb.version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.azure/azure-json/${azure-json-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.azure/azure-xml/${azure-xml-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.azure-core/${azure-core-bundle-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.azure-storage-common/${azure-storage-common-bundle-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.azure-storage-blob/${azure-storage-blob-bundle-version}</bundle>
@@ -391,6 +453,8 @@
     <bundle dependency='true'>mvn:org.reactivestreams/reactive-streams/${reactive-streams-version}</bundle>
     <bundle dependency='true'>mvn:io.projectreactor/reactor-core/${reactor-version}</bundle>
     <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io.tesb.version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.azure/azure-json/${azure-json-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.azure/azure-xml/${azure-xml-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.azure-core/${azure-core-bundle-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.azure-storage-common/${azure-storage-common-bundle-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.azure-storage-blob/${azure-storage-blob-bundle-version}</bundle>
@@ -499,6 +563,8 @@
     <bundle dependency='true'>mvn:org.apache.qpid/qpid-jms-client/${qpid-jms-client.tesb.version}</bundle>
     <bundle dependency='true'>mvn:org.apache.qpid/proton-j/${qpid-proton-j.tesb.version}</bundle>
     <feature version='${camel.tesb.version-range}'>camel-azure-storage-blob</feature>
+    <bundle dependency='true'>wrap:mvn:com.azure/azure-json/${azure-json-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:com.azure/azure-xml/${azure-xml-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.azure-core/${azure-core-bundle-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.azure-core-amqp/${azure-core-amqp-bundle-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.azure-messaging-eventhubs/${azure-messaging-eventhubs-bundle-version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
 
     <properties>
         <upstream.version>3.20.9</upstream.version>
-        <camel.features.tesb.version>3.20.9.20241209</camel.features.tesb.version>
+        <camel.features.tesb.version>3.20.9.20241213</camel.features.tesb.version>
         <camel-base.tesb.version>3.20.9.20240425</camel-base.tesb.version>
         <camel-support.tesb.version>3.20.9.20240425</camel-support.tesb.version>
         <camel-aws.tesb.version>3.20.9.20241202</camel-aws.tesb.version>
@@ -231,6 +231,7 @@
         <!-- Camel target version -->
         <camel-version>3.20.9</camel-version>
 
+        <amazon-kinesis-client-version>2.6.0</amazon-kinesis-client-version>
         <ahc-version>2.12.3</ahc-version>
         <ant-bundle-version>1.7.0_6</ant-bundle-version>
         <antlr-bundle-version>3.5.2_1</antlr-bundle-version>
@@ -248,7 +249,6 @@
         <avalon-bundle-version>4.3.1_1</avalon-bundle-version>
         <avro-java-commons-compress-version>1.21</avro-java-commons-compress-version>
         <avro-jackson-version>2.12.3</avro-jackson-version>
-        <aws-sdk-v2-bundle-version>2.20.99_1</aws-sdk-v2-bundle-version>
         <azure-json-version>1.3.0</azure-json-version>
         <azure-xml-version>1.1.0</azure-xml-version>
         <azure-core-bundle-version>1.34.0_1</azure-core-bundle-version>


### PR DESCRIPTION
🏁 **Context**
- [DPE-420](https://qlik-dev.atlassian.net/browse/DPE-420)

🔍 **What is the problem this PR is trying to solve?**
Cannot run route using camel-sqs, because of missing file in the META-INF of the service mix jar

🚀 **What is the chosen solution to this problem?**
Remove usage of servicemix, use wrap protocol instead.

🎾 **Impacts**

All aws features are impacted

- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

[DPE-369]: https://qlik-dev.atlassian.net/browse/DPE-369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DPE-420]: https://qlik-dev.atlassian.net/browse/DPE-420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ