### PR TITLE
fix(DPE-586) : add missing import to cxf all

### DIFF
--- a/components/camel-cxf/camel-cxf-all/pom.xml
+++ b/components/camel-cxf/camel-cxf-all/pom.xml
@@ -49,7 +49,7 @@
             com.sun.xml.internal.messaging.saaj.soap;resolution:=optional,
             com.ctc.wstx*;resolution:=optional,
             org.codehaus.stax2*;resolution:=optional,
-            org.codehaus.jettison.mapped*;resolution:=optional,
+            org.codehaus.jettison*;resolution:=optional,
             org.dom4j*;resolution:=optional,
             com.sun.msv*;resolution:=optional,
             com.sun.tools*;resolution:=optional,

--- a/components/camel-cxf/camel-cxf-blueprint/pom.xml
+++ b/components/camel-cxf/camel-cxf-blueprint/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>org.apache.camel.karaf</groupId>
             <artifactId>camel-cxf-all</artifactId>
-            <version>${upstream.version}</version>
+            <version>${camel-cxf-all.tesb.version}</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
Missing an import to jettison :
These are now optionals: 
```
        org.codehaus.jettison;resolution:=optional,
        org.codehaus.jettison.badgerfish;resolution:=optional,
        org.codehaus.jettison.json;resolution:=optional,
        org.codehaus.jettison.mapped;resolution:=optional,
        org.codehaus.jettison.util;resolution:=optional,

```

+ fix version in camel-cxf-blueprint