### PR TITLE
DPE-571 Security updates.

### DIFF
--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -175,7 +175,7 @@
     <bundle dependency='true'>mvn:org.bouncycastle/bcprov-jdk18on/${bouncycastle.tesb.version}</bundle>
     <bundle dependency='true'>mvn:org.bouncycastle/bcpkix-jdk18on/${bouncycastle.tesb.version}</bundle>
     <bundle dependency='true'>mvn:org.bouncycastle/bcutil-jdk18on/${bouncycastle.tesb.version}</bundle>
-    <bundle dependency='true'>mvn:org.apache.velocity/velocity-engine-core/${velocity-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.velocity/velocity-engine-core/${velocity.tesb.version}</bundle>
     <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3.tesb.version}</bundle>
     <bundle>mvn:org.apache.camel/camel-as2-api/${upstream.version}</bundle>
     <bundle>mvn:org.apache.camel/camel-as2/${upstream.version}</bundle>
@@ -378,6 +378,8 @@
     <bundle dependency='true'>mvn:org.ow2.asm/asm-tree/${asm.bundle.version}</bundle>
     <bundle dependency='true'>mvn:org.ow2.asm/asm-util/${asm.bundle.version}</bundle>
     <bundle>mvn:org.apache.camel/camel-azure-storage-blob/${upstream.version}</bundle>
+    <bundle dependency="true">wrap:mvn:com.azure/azure-xml/1.0.0$Bundle-Version=1.0.0</bundle>
+    <bundle dependency="true">wrap:mvn:com.azure/azure-json/1.1.0$Bundle-Version=1.1.0</bundle>
   </feature>
   <feature name='camel-azure-storage-datalake' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
@@ -420,6 +422,8 @@
     <bundle dependency='true'>mvn:org.ow2.asm/asm-tree/${asm.bundle.version}</bundle>
     <bundle dependency='true'>mvn:org.ow2.asm/asm-util/${asm.bundle.version}</bundle>
     <bundle>mvn:org.apache.camel/camel-azure-storage-datalake/${upstream.version}</bundle>
+    <bundle dependency="true">wrap:mvn:com.azure/azure-xml/1.0.0$Bundle-Version=1.0.0</bundle>
+    <bundle dependency="true">wrap:mvn:com.azure/azure-json/1.1.0$Bundle-Version=1.1.0</bundle>
   </feature>
   <feature name='camel-azure-storage-queue' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
@@ -437,8 +441,8 @@
     <bundle dependency='true'>wrap:mvn:com.azure/azure-json/${azure-json-version}</bundle>
     <bundle dependency='true'>wrap:mvn:com.azure/azure-xml/${azure-xml-version}</bundle>
     <bundle dependency='true'>wrap:mvn:com.azure/azure-core-http-netty/${azure-core-http-netty-version}$SPI-Provider=com.azure.core.http.HttpClientProvider&amp;Import-Package=reactor.netty.http.client;resolution:=mandatory,*</bundle>
-    <bundle dependency='true'>mvn:io.projectreactor.netty/reactor-netty-core/1.0.23</bundle>
-    <bundle dependency='true'>mvn:io.projectreactor.netty/reactor-netty-http/1.0.23</bundle>
+    <bundle dependency='true'>mvn:io.projectreactor.netty/reactor-netty-core/${reactor-netty.tesb.version}</bundle>
+    <bundle dependency='true'>mvn:io.projectreactor.netty/reactor-netty-http/${reactor-netty.tesb.version}</bundle>
     <bundle dependency='true'>mvn:io.netty/netty-resolver/${netty.tesb.version}</bundle>
     <bundle dependency='true'>mvn:io.netty/netty-resolver-dns/${netty.tesb.version}</bundle>
     <bundle dependency='true'>mvn:io.netty/netty-common/${netty.tesb.version}</bundle>
@@ -1235,7 +1239,7 @@
   </feature>
   <feature name='camel-hl7' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-netty</feature>
-    <bundle dependency='true'>mvn:org.apache.mina/mina-core/${mina-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.mina/mina-core/${mina.tesb.version}</bundle>
     <bundle dependency='true'>mvn:ca.uhn.hapi/hapi-osgi-base/${hapi-version}</bundle>
     <bundle>mvn:org.apache.camel/camel-hl7/${upstream.version}</bundle>
   </feature>
@@ -1645,7 +1649,7 @@
     <bundle dependency='true'>mvn:org.apache.commons/commons-collections4/${commons-collections4-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3.tesb.version}</bundle>
     <bundle dependency='true'>mvn:org.apache.commons/commons-pool2/${commons-pool2-version}</bundle>
-    <bundle dependency='true'>mvn:org.apache.mina/mina-core/${mina-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.mina/mina-core/${mina.tesb.version}</bundle>
     <bundle>mvn:org.apache.camel/camel-ldif/${upstream.version}</bundle>
   </feature>
   <feature name='camel-leveldb' version='${upstream.version}' start-level='50'>
@@ -1748,7 +1752,7 @@
   </feature>
   <feature name='camel-mina' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
-    <bundle dependency='true'>mvn:org.apache.mina/mina-core/${mina-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.mina/mina-core/${mina.tesb.version}</bundle>
     <bundle>mvn:org.apache.camel/camel-mina/${upstream.version}</bundle>
   </feature>
   <feature name='camel-minio' version='${upstream.version}' start-level='50'>
@@ -1990,7 +1994,7 @@
   </feature>
   <feature name='camel-quickfix' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
-    <bundle dependency='true'>mvn:org.apache.mina/mina-core/${mina-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.mina/mina-core/${mina.tesb.version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xmlresolver/${xmlresolver-bundle-version}</bundle>
     <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.saxon/${saxon-bundle-version}</bundle>
     <bundle>mvn:org.quickfixj/quickfixj-all/${quickfixj-version}</bundle>
@@ -2297,7 +2301,7 @@
   </feature>
   <feature name='camel-ssh' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
-    <bundle dependency='true'>mvn:org.apache.mina/mina-core/${mina-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.mina/mina-core/${mina.tesb.version}</bundle>
     <bundle dependency='true'>mvn:org.apache.sshd/sshd-osgi/${sshd.tesb.version}</bundle>
     <bundle dependency='true'>mvn:org.bouncycastle/bcprov-jdk18on/${bouncycastle.tesb.version}</bundle>
     <bundle dependency='true'>mvn:org.bouncycastle/bcpkix-jdk18on/${bouncycastle.tesb.version}</bundle>
@@ -2503,7 +2507,7 @@
   </feature>
   <feature name='camel-velocity' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
-    <bundle dependency='true'>mvn:org.apache.velocity/velocity-engine-core/${velocity-version}</bundle>
+    <bundle dependency='true'>mvn:org.apache.velocity/velocity-engine-core/${velocity.tesb.version}</bundle>
     <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3.tesb.version}</bundle>
     <bundle>mvn:org.apache.camel/camel-velocity/${upstream.version}</bundle>
   </feature>
@@ -2627,8 +2631,8 @@
   <feature name='camel-zendesk' version='${upstream.version}' start-level='50'>
     <feature version='${camel.tesb.version-range}'>camel-core</feature>
     <bundle dependency='true'>wrap:mvn:com.cloudbees.thirdparty/zendesk-java-client/${zendesk-client-version}</bundle>
-    <bundle dependency='true'>wrap:mvn:org.asynchttpclient/async-http-client/${ahc-version}$Export-Package=org.asynchttpclient.*;version=${ahc-version}</bundle>
-    <bundle dependency='true'>wrap:mvn:org.asynchttpclient/async-http-client-netty-utils/${ahc-version}$Export-Package=org.asynchttpclient.netty.util.*;version=${ahc-version}</bundle>
+    <bundle dependency='true'>wrap:mvn:org.asynchttpclient/async-http-client/${ahc.tesb.version}$Export-Package=org.asynchttpclient.*;version=${ahc.tesb.version}</bundle>
+    <bundle dependency='true'>wrap:mvn:org.asynchttpclient/async-http-client-netty-utils/${ahc.tesb.version}$Export-Package=org.asynchttpclient.netty.util.*;version=${ahc.tesb.version}</bundle>
     <bundle dependency='true'>mvn:io.netty/netty-resolver/${netty.tesb.version}</bundle>
     <bundle dependency='true'>mvn:io.netty/netty-common/${netty.tesb.version}</bundle>
     <bundle dependency='true'>mvn:io.netty/netty-buffer/${netty.tesb.version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
 
     <properties>
         <upstream.version>3.20.9</upstream.version>
-        <camel.features.tesb.version>3.20.9.20241209</camel.features.tesb.version>
+        <camel.features.tesb.version>3.20.9.20250110</camel.features.tesb.version>
         <camel-base.tesb.version>3.20.9.20240425</camel-base.tesb.version>
         <camel-support.tesb.version>3.20.9.20240425</camel-support.tesb.version>
         <camel-aws.tesb.version>3.20.9.20241202</camel-aws.tesb.version>
@@ -136,7 +136,7 @@
         <!-- <commons-io1.tesb.version>1.4</commons-io1.tesb.version> -->
         <commons-codec.tesb.version>1.17.0</commons-codec.tesb.version>
         <commons-io.tesb.version>2.16.1</commons-io.tesb.version>
-        <commons-lang3.tesb.version>3.14.0</commons-lang3.tesb.version>
+        <commons-lang3.tesb.version>3.17.0</commons-lang3.tesb.version>
         <commons-net.tesb.version>3.9.0</commons-net.tesb.version>
         <curator.tesb.version>5.5.0</curator.tesb.version>
         <datastax-native-protocol.tesb.version>1.5.1</datastax-native-protocol.tesb.version>
@@ -172,7 +172,7 @@
         <jaxb-bundle.tesb.version>2.3.2_3</jaxb-bundle.tesb.version>
         <jdom-bundle.tesb.version>2.0.6.1_1</jdom-bundle.tesb.version>
         <jettison.tesb.version>1.5.4</jettison.tesb.version>
-        <jetty.tesb.version>9.4.55.v20240627</jetty.tesb.version>
+        <jetty.tesb.version>9.4.56.v20240826</jetty.tesb.version>
         <jgit.tesb.version>6.6.1.202309021850-r</jgit.tesb.version>
         <jna.tesb.version>5.13.0</jna.tesb.version>
         <!-- <johnzon.tesb.version>1.2.21</johnzon.tesb.version> -->
@@ -180,16 +180,17 @@
         <json-path.tesb.version>2.9.0</json-path.tesb.version>
         <json-smart.tesb.version>2.5.0</json-smart.tesb.version>
         <accessors-smart.tesb.version>2.5.0</accessors-smart.tesb.version>
-        <kudu.tesb.version>1.17.0</kudu.tesb.version>
+        <kudu.tesb.version>1.17.1</kudu.tesb.version>
         <libthrift-bundle.tesb.version>0.18.1_1</libthrift-bundle.tesb.version>
         <log4j2.tesb.version>2.20.0</log4j2.tesb.version>
         <metrics.tesb.version>4.2.26</metrics.tesb.version>
-        <netty.tesb.version>4.1.111.Final</netty.tesb.version>
+        <netty.tesb.version>4.1.115.Final</netty.tesb.version>
+        <reactor-netty.tesb.version>1.0.39</reactor-netty.tesb.version>
         <opensaml-bundle.tesb.version>3.4.6_3</opensaml-bundle.tesb.version>
         <opentelemetry.tesb.version>1.34.1</opentelemetry.tesb.version>
         <opentelemetry-alpha.tesb.version>1.26.0-alpha</opentelemetry-alpha.tesb.version>
         <pgjdbc-driver.tesb.version>42.6.1</pgjdbc-driver.tesb.version>
-        <protobuf.tesb.version>3.21.12</protobuf.tesb.version>
+        <protobuf.tesb.version>3.25.5</protobuf.tesb.version>
         <qpid-jms-client.tesb.version>1.9.0</qpid-jms-client.tesb.version>
         <qpid-proton-j.tesb.version>0.34.1</qpid-proton-j.tesb.version>
         <rabbitmq-amqp-client.tesb.version>5.18.0</rabbitmq-amqp-client.tesb.version>
@@ -216,6 +217,9 @@
         <kafka-bundle.tesb.version>3.4.0_1-tesb1</kafka-bundle.tesb.version>
         <xerces-bundle.tesb.version>2.12.2.tesb1_1</xerces-bundle.tesb.version>
         <xalan-bundle.tesb.version>2.7.3_3</xalan-bundle.tesb.version>
+        <velocity.tesb.version>2.4.1</velocity.tesb.version>
+        <mina.tesb.version>2.1.10</mina.tesb.version>
+        <ahc.tesb.version>2.12.4</ahc.tesb.version>
 
         <!-- unify the encoding for all the modules -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -719,6 +723,7 @@
                             <docker-java-commons-compress.tesb.version>${docker-java-commons-compress.tesb.version}</docker-java-commons-compress.tesb.version>
                             <minio-commons-compress.tesb.version>${minio-commons-compress.tesb.version}</minio-commons-compress.tesb.version>
                             <netty.tesb.version>${netty.tesb.version}</netty.tesb.version>
+                            <reactor-netty.tesb.version>${reactor-netty.tesb.version}</reactor-netty.tesb.version>
                             <json-path.tesb.version>${json-path.tesb.version}</json-path.tesb.version>
                             <json-smart.tesb.version>${json-smart.tesb.version}</json-smart.tesb.version>
                             <accessors-smart.tesb.version>${accessors-smart.tesb.version}</accessors-smart.tesb.version>
@@ -775,6 +780,9 @@
                             <zipkin-libthrift.tesb.version>${zipkin-libthrift.tesb.version}</zipkin-libthrift.tesb.version>
                             <xerces-bundle.tesb.version>${xerces-bundle.tesb.version}</xerces-bundle.tesb.version>
                             <xalan-bundle.tesb.version>${xalan-bundle.tesb.version}</xalan-bundle.tesb.version>
+                            <velocity.tesb.version>${velocity.tesb.version}</velocity.tesb.version>
+                            <mina.tesb.version>${mina.tesb.version}</mina.tesb.version>
+                            <ahc.tesb.version>${ahc.tesb.version}</ahc.tesb.version>
                             <zookeeper-curator.tesb.version-range>${zookeeper-curator.tesb.version-range}</zookeeper-curator.tesb.version-range>
                         </properties>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
         <hazelcast.tesb.version>5.3.5</hazelcast.tesb.version>
         <httpclient4.tesb.version>4.5.14</httpclient4.tesb.version>
         <httpcore4.tesb.version>4.4.16</httpcore4.tesb.version>
-        <jackson2.tesb.version>2.16.2</jackson2.tesb.version>
+        <jackson2.tesb.version>2.17.2</jackson2.tesb.version>
         <jackson2-dataformat-yaml.tesb.version>2.14.3</jackson2-dataformat-yaml.tesb.version>
         <jakarta-el.tesb.version>3.0.4</jakarta-el.tesb.version>
         <jakarta-validation-api.tesb.version>2.0.2</jakarta-validation-api.tesb.version>


### PR DESCRIPTION
kudu-client 1.17.0 -> 1.17.1 - CVE-2024-7254(protobuf) CVE-2024-29025(netty) CVE-2023-44487(netty) CVE-2023-47535(netty)
protobuf 3.21.12 -> 3.25.5 - CVE-2024-7254
velocity-engine-core 2.3 -> 2.4.1 - CVE-2024-47554(commons-io)
netty 4.1.111.Final -> 4.1.115.Final - CVE-2024-47535
reactor-netty 1.0.23 -> 1.0.39 - CVE-2023-34054 CVE-2023-34062 CVE-2022-31684
mina 2.1.6,2.1.8 -> 2.1.10 - CVE-2024-52046
async-http-client 2.12.3 -> 2.12.4 - CVE-2024-53990
jetty 9.4.55.v20240627 -> 9.4.56.v20240826 - CVE-2024-8184