### PR TITLE
fix(DPE-562): Properly set the version of camel-aws2-kinesis

### DIFF
--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -569,7 +569,7 @@
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/aws-json-protocol/${aws-java-sdk2-version}</bundle>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/aws-cbor-protocol/${aws-java-sdk2-version}</bundle>
         <bundle dependency='true'>wrap:mvn:software.amazon.awssdk/third-party-jackson-dataformat-cbor/${aws-java-sdk2-version}</bundle>
-        <bundle>mvn:org.apache.camel.karaf/camel-aws2-kinesis/${project.version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-aws2-kinesis/${upstream.version}</bundle>
     </feature>
     <feature name='camel-aws2-kms' version='${upstream.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>


### PR DESCRIPTION
🏁 **Context**
- [DPE-562](https://qlik-dev.atlassian.net/browse/DPE-562)

🔍 **What is the problem this PR is trying to solve?**
the last change breaks the build https://jenkins-esb.datapwn.com/job/camel-karaf/job/tesb%252Fcamel-karaf-4.8.1.x/13/

🚀 **What is the chosen solution to this problem?**
Set properly the version of the bundle camel-aws2-kinesis

🎾 **Impacts**

Only aws kinesis feature is impacted

- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR


[DPE-562]: https://qlik-dev.atlassian.net/browse/DPE-562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ