### PR TITLE
fix(DPE-642): Add Groovy subprojects to camel-groovy

### DIFF
--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -1453,6 +1453,28 @@
     <feature name='camel-groovy' version='${upstream.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:org.apache.groovy/groovy/${groovy-version}</bundle>
+        <!-- Talend additions begin -->
+        <bundle dependency='true'>mvn:org.apache.groovy/groovy-ant/${groovy-version}</bundle>
+        <!-- <bundle dependency='true'>mvn:org.apache.groovy/groovy-cli-commons/${groovy-version}</bundle> -->
+        <!-- <bundle dependency='true'>mvn:org.apache.groovy/groovy-cli-picocli/${groovy-version}</bundle> -->
+        <!-- <bundle dependency='true'>mvn:org.apache.groovy/groovy-console/${groovy-version}</bundle> -->
+        <bundle dependency='true'>mvn:org.apache.groovy/groovy-datetime/${groovy-version}</bundle>
+        <!-- <bundle dependency='true'>mvn:org.apache.groovy/groovy-docgenerator/${groovy-version}</bundle> -->
+        <!-- <bundle dependency='true'>mvn:org.apache.groovy/groovy-groovydoc/${groovy-version}</bundle> -->
+        <!-- <bundle dependency='true'>mvn:org.apache.groovy/groovy-groovysh/${groovy-version}</bundle> -->
+        <!-- <bundle dependency='true'>mvn:org.apache.groovy/groovy-jmx/${groovy-version}</bundle> -->
+        <bundle dependency='true'>mvn:org.apache.groovy/groovy-json/${groovy-version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.groovy/groovy-macro/${groovy-version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.groovy/groovy-nio/${groovy-version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.groovy/groovy-servlet/${groovy-version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.groovy/groovy-sql/${groovy-version}</bundle>
+        <!-- <bundle dependency='true'>mvn:org.apache.groovy/groovy-swing/${groovy-version}</bundle> -->
+        <bundle dependency='true'>mvn:org.apache.groovy/groovy-templates/${groovy-version}</bundle>
+        <!-- <bundle dependency='true'>mvn:org.apache.groovy/groovy-test/${groovy-version}</bundle> -->
+        <!-- <bundle dependency='true'>mvn:org.apache.groovy/groovy-test-junit5/${groovy-version}</bundle> -->
+        <!-- <bundle dependency='true'>mvn:org.apache.groovy/groovy-testng/${groovy-version}</bundle> -->
+        <bundle dependency='true'>mvn:org.apache.groovy/groovy-xml/${groovy-version}</bundle>
+        <!-- Talend additions end -->
         <bundle>mvn:org.apache.camel.karaf/camel-groovy/${upstream.version}</bundle>
     </feature>
     <feature name='camel-grok' version='${upstream.version}' start-level='50'>


### PR DESCRIPTION
🏁 **Context**
- [DPE-642](https://qlik-dev.atlassian.net/browse/DPE-642)

🔍 **What is the problem this PR is trying to solve?**

The test assumes that groovy-json is pre-installed like in 3.20.9

🚀 **What is the chosen solution to this problem?**
Add the same subprojects of groovy to camel-groovy like in 3.20.9 for consistency

🎾 **Impacts**

- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

[DPE-642]: https://qlik-dev.atlassian.net/browse/DPE-642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ