### PR TITLE
fix(DPE-643): Add camel-vm to custom modules

### DIFF
--- a/Jenkinsfile.talend
+++ b/Jenkinsfile.talend
@@ -1,5 +1,5 @@
 @Library('esb') _
  
 Fork(
-        MVN_MODULES: 'org.apache.camel.karaf:camel-support,org.apache.camel.karaf:camel-blueprint,org.apache.camel.karaf:camel-cxf-all,org.apache.camel.karaf:camel-cxf-blueprint,org.apache.camel.karaf:camel-cxf-spring-all,org.apache.camel.karaf:camel-cxf-transport-blueprint,org.apache.camel.karaf:camel-spring,org.apache.camel.karaf:apache-camel'
+        MVN_MODULES: 'org.apache.camel.karaf:camel-support,org.apache.camel.karaf:camel-vm,org.apache.camel.karaf:camel-blueprint,org.apache.camel.karaf:camel-cxf-all,org.apache.camel.karaf:camel-cxf-blueprint,org.apache.camel.karaf:camel-cxf-spring-all,org.apache.camel.karaf:camel-cxf-transport-blueprint,org.apache.camel.karaf:camel-spring,org.apache.camel.karaf:apache-camel'
 )

--- a/components/camel-vm/pom.xml
+++ b/components/camel-vm/pom.xml
@@ -31,8 +31,10 @@
     <artifactId>camel-vm</artifactId>
     <packaging>bundle</packaging>
     <name>Apache Camel :: Karaf :: Components :: VM</name>
+    <version>${revision}</version>
 
     <properties>
+        <revision>${camel-vm.tesb.version}</revision>
         <camel.osgi.export>
             org.apache.camel.karaf.component.vm.*;version=${camel-version}
         </camel.osgi.export>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -338,7 +338,7 @@
         <bundle>mvn:org.apache.camel.karaf/camel-xpath/${upstream.version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-xslt/${upstream.version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-directvm/${upstream.version}</bundle>
-        <bundle>mvn:org.apache.camel.karaf/camel-vm/${upstream.version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-vm/${camel-vm.tesb.version}</bundle>
         <conditional>
             <condition>shell</condition>
             <bundle>mvn:org.apache.camel.karaf/camel-karaf-shell/${upstream.version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
         <upstream.version>4.8.1</upstream.version>
         <camel-features.tesb.version>4.8.1.20240820</camel-features.tesb.version>
         <camel-support.tesb.version>4.8.1.20240820</camel-support.tesb.version>
+        <camel-vm.tesb.version>4.8.1.20240820</camel-vm.tesb.version>
         <camel-cxf.tesb.version>4.8.1.20240820</camel-cxf.tesb.version>
         <camel-cxf-all.tesb.version>4.8.1.20240820</camel-cxf-all.tesb.version>
         <camel-cxf-soap.tesb.version>4.8.1.20240820</camel-cxf-soap.tesb.version>
@@ -740,6 +741,7 @@
                             <upstream.version>${upstream.version}</upstream.version>
                             <camel.features.tesb.version>${camel.features.tesb.version}</camel.features.tesb.version>
                             <camel-support.tesb.version>${camel-support.tesb.version}</camel-support.tesb.version>
+                            <camel-vm.tesb.version>${camel-vm.tesb.version}</camel-vm.tesb.version>
                             <camel-cxf.tesb.version>${camel-cxf.tesb.version}</camel-cxf.tesb.version>
                             <camel-cxf-all.tesb.version>${camel-cxf-all.tesb.version}</camel-cxf-all.tesb.version>
                             <camel-cxf-soap.tesb.version>${camel-cxf-soap.tesb.version}</camel-cxf-soap.tesb.version>


### PR DESCRIPTION
🏁 **Context**
- [DPE-643](https://qlik-dev.atlassian.net/browse/DPE-643)

🔍 **What is the problem this PR is trying to solve?**

The wrapper camel-vm has been modified so it needs to be part of the custom modules

🚀 **What is the chosen solution to this problem?**
Add camel-vm to custom modules

🎾 **Impacts**

- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

[DPE-643]: https://qlik-dev-sandbox-345.atlassian.net/browse/DPE-643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ