### PR TITLE
DPE-501: avoid unnecessary updates of activemq-osgi

### DIFF
--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -159,7 +159,7 @@
     <bundle dependency='true'>mvn:commons-net/commons-net/${commons-net.tesb.version}</bundle>
     <feature version="${zookeeper.tesb.version}">zookeeper-core</feature>
     <bundle>mvn:org.apache.activemq/activemq-pool/${activemq-pool.tesb.version}</bundle>
-    <bundle>wrap:mvn:org.apache.activemq/activemq-osgi/${activemq-osgi.tesb.version}$overwrite=merge&amp;Import-Package=org.springframework.*;resolution:=optional;version="[5,6)",*;resolution:=optional</bundle>
+    <bundle dependency='true'>mvn:org.apache.activemq/activemq-osgi/${activemq-osgi.tesb.version}</bundle>
     <!-- <bundle>mvn:org.apache.camel/camel-activemq/${upstream.version}</bundle> -->
     <bundle>wrap:mvn:org.apache.camel/camel-activemq/${upstream.version}$overwrite=merge&amp;Import-Package=org.apache.activemq.pool,javax.jms;version="[1.1,3)",*</bundle>
   </feature>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
 
     <properties>
         <upstream.version>3.20.9</upstream.version>
-        <camel.features.tesb.version>3.20.9.20250110</camel.features.tesb.version>
+        <camel.features.tesb.version>3.20.9.20250210</camel.features.tesb.version>
         <camel-base.tesb.version>3.20.9.20240425</camel-base.tesb.version>
         <camel-support.tesb.version>3.20.9.20240425</camel-support.tesb.version>
         <camel-aws.tesb.version>3.20.9.20241202</camel-aws.tesb.version>


### PR DESCRIPTION
🏁 **Context**
- [DPE-501](https://qlik-dev.atlassian.net/browse/DPE-501)

🔍 **What is the problem this PR is trying to solve?**
`Reason: java.io.IOException: Transport scheme NOT recognized`
`reason: java.io.IOException: Service not found: 'META-INF/services/org/apache/activemq/wireformat/default'`
When the `activemq-osgi` bundle is updated, the references to the services it provides are lost: https://stackoverflow.com/questions/22987656/transport-scheme-not-recognized-tcp.

🚀 **What is the chosen solution to this problem?**
Remove the unnecessary wrap protocol on the bundle and declare the bundle as `dependency` where needed.

🎾 **Impacts**
- [x] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR


[DPE-501]: https://qlik-dev.atlassian.net/browse/DPE-501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ