### PR TITLE
DPE-761: replace invalid bundle version

### DIFF
--- a/platforms/karaf/features/src/main/resources/features.xml
+++ b/platforms/karaf/features/src/main/resources/features.xml
@@ -1863,7 +1863,7 @@
     <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-api/${opentelemetry.tesb.version}$Bundle-SymbolicName=opentelemetry-api&amp;Bundle-Version=${opentelemetry.tesb.version}</bundle>
     <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-sdk/${opentelemetry.tesb.version}$Bundle-SymbolicName=opentelemetry-sdk&amp;Bundle-Version=${opentelemetry.tesb.version}</bundle>
     <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-context/${opentelemetry.tesb.version}$Bundle-SymbolicName=opentelemetry-context&amp;Bundle-Version=${opentelemetry.tesb.version}</bundle>
-    <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-semconv/${opentelemetry-alpha.tesb.version}$Bundle-SymbolicName=opentelemetry-semconv&amp;Bundle-Version=${opentelemetry-alpha.tesb.version}</bundle>
+    <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-semconv/${opentelemetry-alpha.tesb.version}$Bundle-SymbolicName=opentelemetry-semconv&amp;Bundle-Version=${opentelemetry-alpha.bundle.tesb.version}</bundle>
     <bundle>mvn:org.apache.camel/camel-opentelemetry/${upstream.version}</bundle>
   </feature>
   <feature name='camel-paho' version='${upstream.version}' start-level='50'>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
 
     <properties>
         <upstream.version>3.20.9</upstream.version>
-        <camel.features.tesb.version>3.20.9.20250210</camel.features.tesb.version>
+        <camel.features.tesb.version>3.20.9.20250213</camel.features.tesb.version>
         <camel-base.tesb.version>3.20.9.20240425</camel-base.tesb.version>
         <camel-support.tesb.version>3.20.9.20240425</camel-support.tesb.version>
         <camel-aws.tesb.version>3.20.9.20241202</camel-aws.tesb.version>
@@ -190,6 +190,7 @@
         <opensaml-bundle.tesb.version>3.4.6_3</opensaml-bundle.tesb.version>
         <opentelemetry.tesb.version>1.34.1</opentelemetry.tesb.version>
         <opentelemetry-alpha.tesb.version>1.26.0-alpha</opentelemetry-alpha.tesb.version>
+        <opentelemetry-alpha.bundle.tesb.version>1.26.0.alpha</opentelemetry-alpha.bundle.tesb.version>
         <pgjdbc-driver.tesb.version>42.6.1</pgjdbc-driver.tesb.version>
         <protobuf.tesb.version>3.25.5</protobuf.tesb.version>
         <qpid-jms-client.tesb.version>1.9.0</qpid-jms-client.tesb.version>
@@ -770,6 +771,7 @@
                             <opensaml-bundle.tesb.version>${opensaml-bundle.tesb.version}</opensaml-bundle.tesb.version>
                             <opentelemetry.tesb.version>${opentelemetry.tesb.version}</opentelemetry.tesb.version>
                             <opentelemetry-alpha.tesb.version>${opentelemetry-alpha.tesb.version}</opentelemetry-alpha.tesb.version>
+                            <opentelemetry-alpha.bundle.tesb.version>${opentelemetry-alpha.bundle.tesb.version}</opentelemetry-alpha.bundle.tesb.version>
                             <pgjdbc-driver.tesb.version>${pgjdbc-driver.tesb.version}</pgjdbc-driver.tesb.version>
                             <vertx.tesb.version>${vertx.tesb.version}</vertx.tesb.version>
                             <spring.tesb.version-range>${spring.tesb.version-range}</spring.tesb.version-range>


### PR DESCRIPTION
🏁 **Context**
- [DPE-761](https://qlik-dev.atlassian.net/browse/DPE-761)

🔍 **What is the problem this PR is trying to solve?**
`opentelemetry` feature include bundle with invalid version

🚀 **What is the chosen solution to this problem?**
Override the `Bundle-Version` header with a valid version.

🎾 **Impacts**
- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

[DPE-761]: https://qlik-dev.atlassian.net/browse/DPE-761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ