### PR TITLE
DPE-852 Fix DefaultHeaderFilterStrategy lowercase filtering.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,8 +88,8 @@
     <!-- TODO use Karaf/Camel bom -->
     <properties>
         <upstream.version>4.8.1</upstream.version>
-        <camel-features.tesb.version>4.8.1.20240820</camel-features.tesb.version>
-        <camel-support.tesb.version>4.8.1.20240820</camel-support.tesb.version>
+        <camel-features.tesb.version>4.8.1.20250310</camel-features.tesb.version>
+        <camel-support.tesb.version>4.8.1.20250310</camel-support.tesb.version>
         <camel-vm.tesb.version>4.8.1.20240820</camel-vm.tesb.version>
         <camel-cxf.tesb.version>4.8.1.20240820</camel-cxf.tesb.version>
         <camel-cxf-all.tesb.version>4.8.1.20240820</camel-cxf-all.tesb.version>


### PR DESCRIPTION
CVE-2025-27636 - backport of fix from Camel 4.8.5.