### PR TITLE
DPE-852 Fix DefaultHeaderFilterStrategy lowercase filtering.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,9 +97,9 @@
 
     <properties>
         <upstream.version>3.20.9</upstream.version>
-        <camel.features.tesb.version>3.20.9.20250213</camel.features.tesb.version>
+        <camel.features.tesb.version>3.20.9.20250310</camel.features.tesb.version>
         <camel-base.tesb.version>3.20.9.20240425</camel-base.tesb.version>
-        <camel-support.tesb.version>3.20.9.20240425</camel-support.tesb.version>
+        <camel-support.tesb.version>3.20.9.20250310</camel-support.tesb.version>
         <camel-aws.tesb.version>3.20.9.20241202</camel-aws.tesb.version>
         <camel-cassandraql.tesb.version>3.20.9.20240425</camel-cassandraql.tesb.version>
         <camel-cxf-soap.tesb.version>3.20.9.20240425</camel-cxf-soap.tesb.version>


### PR DESCRIPTION
CVE-2025-27636 - backport of fix from Camel 3.22.4.