### PR TITLE
DPE-1481 Security fixes.

### DIFF
--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -1169,13 +1169,15 @@
         <bundle dependency='true'>wrap:mvn:org.elasticsearch.client/elasticsearch-rest-client-sniffer/${elasticsearch-java-client-sniffer-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-elasticsearch-rest-client/${upstream.version}</bundle>
     </feature>
-    <feature name='camel-elytron' version='${upstream.version}' start-level='50'>
+    <!-- camel-elytron is disabled because of CVE-2024-1233 -->
+    <feature name='camel-elytron' version='${upstream.version}' start-level='50'/>
+    <!-- <feature name='camel-elytron' version='${upstream.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='${camel-osgi-version-range}'>camel-undertow</feature>
         <bundle dependency='true'>wrap:mvn:org.wildfly.security.elytron-web/undertow-server/${elytron-web}</bundle>
         <bundle dependency='true'>wrap:mvn:org.wildfly.security/wildfly-elytron/${wildfly-elytron.tesb.version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-elytron/${upstream.version}</bundle>
-    </feature>
+    </feature> -->
     <feature name='camel-etcd3' version='${upstream.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='${camel-osgi-jackson2.tesb.version}'>jackson</feature>
@@ -1553,7 +1555,7 @@
     </feature>
     <feature name='camel-hazelcast' version='${upstream.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
-        <bundle dependency='true'>mvn:com.hazelcast/hazelcast/${hazelcast-version}</bundle>
+        <bundle dependency='true'>mvn:com.hazelcast/hazelcast/${hazelcast.tesb.version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-hazelcast/${upstream.version}</bundle>
     </feature>
     <feature name='camel-headersmap' version='${upstream.version}' start-level='50'>
@@ -2444,7 +2446,7 @@
     </feature>
     <feature name='camel-pg-replication-slot' version='${upstream.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
-        <bundle dependency='true'>mvn:org.postgresql/postgresql/${pgjdbc-driver-version}</bundle>
+        <bundle dependency='true'>mvn:org.postgresql/postgresql/${pgjdbc-driver.tesb.version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-pg-replication-slot/${upstream.version}</bundle>
     </feature>
     <feature name='camel-pgevent' version='${upstream.version}' start-level='50'>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -1777,7 +1777,7 @@
     <feature name='camel-jcr' version='${upstream.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:javax.jcr/jcr/${jcr-version}</bundle>
-        <bundle dependency='true'>mvn:org.apache.jackrabbit/jackrabbit-jcr-commons/${jackrabbit-version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.jackrabbit/jackrabbit-jcr-commons/${jackrabbit.tesb.version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-jcr/${upstream.version}</bundle>
     </feature>
     <feature name='camel-jdbc' version='${upstream.version}' start-level='50'>

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,7 @@
         <infinispan.tesb.version>15.0.11.Final</infinispan.tesb.version>
         <jackson-asl.tesb.version>1.9.16-TALEND</jackson-asl.tesb.version>
         <jackson2.tesb.version>2.18.3</jackson2.tesb.version>
+        <jackrabbit.tesb.version>2.22.1</jackrabbit.tesb.version>
         <jaxb3-istack.tesb.version>4.0.1</jaxb3-istack.tesb.version>
         <jaxb3-fastinfoset.tesb.version>2.0.0</jaxb3-fastinfoset.tesb.version>
         <jaxb3-staxex.tesb.version>2.0.1</jaxb3-staxex.tesb.version>
@@ -943,6 +944,7 @@
                             <infinispan.tesb.version>${infinispan.tesb.version}</infinispan.tesb.version>
                             <jackson-asl.tesb.version>${jackson-asl.tesb.version}</jackson-asl.tesb.version>
                             <jackson2.tesb.version>${jackson2.tesb.version}</jackson2.tesb.version>
+                            <jackrabbit.tesb.version>${jackrabbit.tesb.version}</jackrabbit.tesb.version>
                             <jaxb3-istack.tesb.version>${jaxb3-istack.tesb.version}</jaxb3-istack.tesb.version>
                             <jaxb3-fastinfoset.tesb.version>${jaxb3-fastinfoset.tesb.version}</jaxb3-fastinfoset.tesb.version>
                             <jaxb3-staxex.tesb.version>${jaxb3-staxex.tesb.version}</jaxb3-staxex.tesb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <!-- TODO use Karaf/Camel bom -->
     <properties>
         <upstream.version>4.8.1</upstream.version>
-        <camel-features.tesb.version>4.8.1.20250625</camel-features.tesb.version>
+        <camel-features.tesb.version>4.8.1.20250630</camel-features.tesb.version>
         <camel-support.tesb.version>4.8.1.20250320</camel-support.tesb.version>
         <camel-vm.tesb.version>4.8.1.20250320</camel-vm.tesb.version>
         <camel-activemq.tesb.version>4.8.1.20250320</camel-activemq.tesb.version>
@@ -183,6 +183,7 @@
         <google-cloud-secretmanager.tesb.version>2.48.0</google-cloud-secretmanager.tesb.version>
         <google-cloud-storage-version>2.42.0</google-cloud-storage-version>
         <groovy.tesb.version>4.0.25</groovy.tesb.version>
+        <hazelcast.tesb.version>5.5.0.tesb1</hazelcast.tesb.version>
         <infinispan.tesb.version>15.0.11.Final</infinispan.tesb.version>
         <jackson-asl.tesb.version>1.9.16-TALEND</jackson-asl.tesb.version>
         <jackson2.tesb.version>2.18.3</jackson2.tesb.version>
@@ -213,6 +214,7 @@
         <netty.tesb.version>4.1.119.Final</netty.tesb.version>
         <paranamer.tesb.version>2.8</paranamer.tesb.version>
         <parquet-avro.tesb.version>1.15.2</parquet-avro.tesb.version>
+        <pgjdbc-driver.tesb.version>42.7.7</pgjdbc-driver.tesb.version>
         <pooled-jms.tesb.version>3.1.7</pooled-jms.tesb.version>
         <protobuf.tesb.version>3.25.5</protobuf.tesb.version>
         <pulsar.tesb.version>3.3.3</pulsar.tesb.version>
@@ -937,6 +939,7 @@
                             <google-cloud-secretmanager.tesb.version>${google-cloud-secretmanager.tesb.version}</google-cloud-secretmanager.tesb.version>
                             <google-cloud-storage-version>${google-cloud-storage-version}</google-cloud-storage-version>
                             <groovy.tesb.version>${groovy.tesb.version}</groovy.tesb.version>
+                            <hazelcast.tesb.version>${hazelcast.tesb.version}</hazelcast.tesb.version>
                             <infinispan.tesb.version>${infinispan.tesb.version}</infinispan.tesb.version>
                             <jackson-asl.tesb.version>${jackson-asl.tesb.version}</jackson-asl.tesb.version>
                             <jackson2.tesb.version>${jackson2.tesb.version}</jackson2.tesb.version>
@@ -967,6 +970,7 @@
                             <netty.tesb.version>${netty.tesb.version}</netty.tesb.version>
                             <paranamer.tesb.version>${paranamer.tesb.version}</paranamer.tesb.version>
                             <parquet-avro.tesb.version>${parquet-avro.tesb.version}</parquet-avro.tesb.version>
+                            <pgjdbc-driver.tesb.version>${pgjdbc-driver.tesb.version}</pgjdbc-driver.tesb.version>
                             <pooled-jms.tesb.version>${pooled-jms.tesb.version}</pooled-jms.tesb.version>
                             <protobuf.tesb.version>${protobuf.tesb.version}</protobuf.tesb.version>
                             <pulsar.tesb.version>${pulsar.tesb.version}</pulsar.tesb.version>


### PR DESCRIPTION
CVE-2025-52999 hazelcast 5.4.0 -> 5.5.0 (embedded Jackson core 2.14.2 -> 2.17.2) CVE-2025-49146 postgresql jdbc driver 42.7.4 -> 42.7.7 CVE-2024-1233 disable camel-elytron (deprecated fro removal by camel)