### PR TITLE
fix(DPE-1315): force netty resolution

### DIFF
--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -280,7 +280,8 @@
 
     <!-- Wrapped zookeeper jars. -->
     <feature name='zookeeper-core' version='${zookeeper.tesb.version}' start-level='50'>
-        <bundle dependency='true'>wrap:mvn:org.apache.zookeeper/zookeeper/${zookeeper-server.tesb.version}$Bundle-SymbolicName=org.apache.zookeeper&amp;Bundle-Version=${zookeeper.tesb.version}&amp;Export-Package=org.apache.zookeeper;version=${zookeeper.tesb.version},org.apache.zookeeper.*;version=${zookeeper.tesb.version}</bundle>
+        <feature version='[4.1,5)'>netty</feature>
+        <bundle dependency='true'>wrap:mvn:org.apache.zookeeper/zookeeper/${zookeeper-server.tesb.version}$Bundle-SymbolicName=org.apache.zookeeper&amp;Bundle-Version=${zookeeper.tesb.version}&amp;Import-Package=io.netty.handler.ssl*;resolution:=mandatory,com*;resolution:=optional,io.netty*;resolution:=optional,jakarta*;resolution:=optional,javax*;resolution:=optional,jline*;resolution:=optional,org.apache.log4j*;resolution:=optional,org.apache.yetus*;resolution:=optional,org.eclipse*;resolution:=optional,org.ietf*;resolution:=optional,org.slf4j*;resolution:=optional,org.xerial*;resolution:=optional&amp;Export-Package=org.apache.zookeeper;version=${zookeeper.tesb.version},org.apache.zookeeper.*;version=${zookeeper.tesb.version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.apache.zookeeper/zookeeper-jute/${zookeeper.tesb.version}$Bundle-SymbolicName=org.apache.zookeeper-jute&amp;Bundle-Version=${zookeeper.tesb.version}&amp;Fragment-Host=org.apache.zookeeper&amp;Export-Package=org.apache.jute;version=${zookeeper.tesb.version},org.apache.zookeeper.*;version=${zookeeper.tesb.version}</bundle>
     </feature>
 


### PR DESCRIPTION
🏁 **Context**
- [DPE-1315](https://qlik-dev.atlassian.net/browse/DPE-1315)

🔍 **What is the problem this PR is trying to solve?**
During patch, zookeeper has only optional Import on netty, so the refresh does not happen correctly

🚀 **What is the chosen solution to this problem?**
Enforce netty import so that refresh is correctly done

🎾 **Impacts**
- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR


[DPE-1704]: https://qlik-dev.atlassian.net/browse/DPE-1704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DPE-1315]: https://qlik-dev.atlassian.net/browse/DPE-1315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ