### PR TITLE
DPE-3094 Security updates.

### DIFF
--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -985,7 +985,7 @@
         <feature version="[3,4)">jakarta-validation</feature>
         <bundle dependency="true">mvn:org.ops4j.pax.web/pax-web-api/${tesb-pax-web-api-version}</bundle>
         <bundle dependency="true">mvn:org.glassfish.hk2/osgi-resource-locator/${osgi-resource-locator-version}</bundle>
-        <bundle dependency="true">mvn:org.apache.neethi/neethi/${auto-detect-version}</bundle>
+        <bundle dependency="true">mvn:org.apache.neethi/neethi/${neethi.tesb.version}</bundle>
         <bundle dependency="true">mvn:org.apache.ws.xmlschema/xmlschema-core/${auto-detect-version}</bundle>
         <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.cglib/${cglib-version}_1</bundle>
         <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.wsdl4j/${auto-detect-version:alias=wsdl4j/wsdl4j}_1</bundle>
@@ -1075,7 +1075,7 @@
     <feature name='camel-debezium-postgres' version='${upstream.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-debezium-common</feature>
         <bundle dependency='true'>wrap:mvn:io.debezium/debezium-connector-postgres/${debezium-version}</bundle>
-        <bundle dependency='true'>mvn:org.postgresql/postgresql/${auto-detect-version}</bundle>
+        <bundle dependency='true'>mvn:org.postgresql/postgresql/${pgjdbc-driver.tesb.version}</bundle>
         <bundle dependency='true'>mvn:com.google.protobuf/protobuf-java/${protobuf.tesb.version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-debezium-postgres/${camel-debezium-postgres.tesb.version}</bundle>
     </feature>
@@ -1180,8 +1180,9 @@
         <bundle dependency="true">mvn:org.glassfish.hk2/osgi-resource-locator/${osgi-resource-locator-version}</bundle>
         <bundle dependency="true">mvn:org.eclipse.parsson/parsson/${parson-version}</bundle>
         <bundle dependency='true'>mvn:jakarta.json/jakarta.json-api/${jakarta-json-api-version}</bundle>
-        <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-api/${opentelemetry-version}</bundle>
-        <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-context/${opentelemetry-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-api/${opentelemetry.tesb.version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-common/${opentelemetry.tesb.version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-context/${opentelemetry.tesb.version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.apache.httpcomponents/httpasyncclient/${httpasyncclient-version}</bundle>
         <bundle dependency='true'>wrap:mvn:co.elastic.clients/elasticsearch-java/${elasticsearch-java-client-version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.elasticsearch.client/elasticsearch-rest-client/${elasticsearch-java-client-version}</bundle>
@@ -1237,8 +1238,10 @@
         <bundle dependency='true'>mvn:org.apache.commons/commons-text/${commons-text.tesb.version}</bundle>
         <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3.tesb.version}</bundle>
         <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io.tesb.version}</bundle>
-        <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-api/${auto-detect-version}</bundle>
-        <bundle dependency='true'>wrap:mvn:io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/${auto-detect-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-api/${opentelemetry.tesb.version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-common/${opentelemetry.tesb.version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-context/${opentelemetry.tesb.version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.opentelemetry.instrumentation/opentelemetry-instrumentation-annotations/${opentelemetry-instrumentation.tesb.version}</bundle>
         <bundle dependency='true'>mvn:ca.uhn.hapi.fhir/hapi-fhir-base/${hapi-fhir-version}</bundle>
         <bundle dependency='true'>mvn:ca.uhn.hapi.fhir/hapi-fhir-client/${hapi-fhir-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-fhir/${upstream.version}</bundle>
@@ -2450,9 +2453,10 @@
     <feature name='camel-opentelemetry' version='${upstream.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='${camel-osgi-version-range}'>camel-tracing</feature>
-        <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-api/${opentelemetry-version}</bundle>
-        <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-sdk/${opentelemetry-version}</bundle>
-        <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-context/${opentelemetry-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-api/${opentelemetry.tesb.version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-common/${opentelemetry.tesb.version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-sdk/${opentelemetry.tesb.version}</bundle>
+        <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-context/${opentelemetry.tesb.version}</bundle>
         <bundle dependency='true'>wrap:mvn:io.opentelemetry/opentelemetry-semconv/${opentelemetry-alpha-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-opentelemetry/${upstream.version}</bundle>
     </feature>
@@ -3075,7 +3079,7 @@
     </feature>
     <feature name='camel-thymeleaf' version='${upstream.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
-        <bundle dependency='true'>wrap:mvn:org.thymeleaf/thymeleaf/${thymeleaf-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:org.thymeleaf/thymeleaf/${thymeleaf.tesb.version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-thymeleaf/${upstream.version}</bundle>
     </feature>
     <feature name='camel-tika' version='${upstream.version}' start-level='50'>

--- a/pom.xml
+++ b/pom.xml
@@ -240,7 +240,7 @@
         <langchain4j.tesb.version>1.6.0</langchain4j.tesb.version>
         <langchain4j-mcp.tesb.version>1.6.0-beta12</langchain4j-mcp.tesb.version>
         <logback.tesb.version>1.5.18</logback.tesb.version>
-        <lz4-java.tesb.version>1.10.1</lz4-java.tesb.version>
+        <lz4-java.tesb.version>1.10.3</lz4-java.tesb.version>
         <metrics.tesb.version>4.2.30</metrics.tesb.version>
         <micrometer.tesb.version>1.13.11</micrometer.tesb.version>
         <micrometer-tracing.tesb.version>1.3.9</micrometer-tracing.tesb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <!-- TODO use Karaf/Camel bom -->
     <properties>
         <upstream.version>4.8.1</upstream.version>
-        <camel-features.tesb.version>4.8.1.20260323</camel-features.tesb.version>
+        <camel-features.tesb.version>4.8.1.20260512</camel-features.tesb.version>
         <camel-support.tesb.version>4.8.1.20260120</camel-support.tesb.version>
         <camel-vm.tesb.version>4.8.1.20250320</camel-vm.tesb.version>
         <camel-activemq.tesb.version>4.8.1.20250320</camel-activemq.tesb.version>
@@ -159,24 +159,24 @@
         <!-- <camel-support.tesb.version>4.8.1.20250320</camel-support.tesb.version> -->
 
         <cxf.tesb.version>4.1.0.2</cxf.tesb.version>
-        <jetty9.tesb.version>9.4.57.v20241219</jetty9.tesb.version>
+        <jetty9.tesb.version>9.4.58.v20250814</jetty9.tesb.version>
         <jetty11.tesb.version>11.0.26</jetty11.tesb.version>
         <jetty12.tesb.version>12.0.33</jetty12.tesb.version>
         <jetty.tesb.version>${jetty12.tesb.version}</jetty.tesb.version>
         <jetty11.tesb.version-range>[11,12)</jetty11.tesb.version-range>
         <jetty12.tesb.version-range>[12,13)</jetty12.tesb.version-range>
         <jetty.tesb.version-range>${jetty12.tesb.version-range}</jetty.tesb.version-range>
-        <activemq6.tesb.version>6.2.2</activemq6.tesb.version>
+        <activemq6.tesb.version>6.2.5</activemq6.tesb.version>
         <activemq-artemis.tesb.version>2.40.0</activemq-artemis.tesb.version>
         <angus-mail.tesb.version>2.0.4</angus-mail.tesb.version>
         <apache-drill.tesb.version>1.22.0</apache-drill.tesb.version>
         <asm.tesb.version>9.8</asm.tesb.version>
-        <async-http-client.tesb.version>2.12.4</async-http-client.tesb.version>
+        <async-http-client.tesb.version>2.15.0</async-http-client.tesb.version>
         <azure-json.tesb.version>1.3.0</azure-json.tesb.version>
         <azure-storage-common.tesb.version>12.26.1</azure-storage-common.tesb.version>
         <azure-xml.tesb.version>1.1.0</azure-xml.tesb.version>
         <beanio.tesb.version>3.2.0</beanio.tesb.version>
-        <bouncycastle.tesb.version>1.81</bouncycastle.tesb.version>
+        <bouncycastle.tesb.version>1.84</bouncycastle.tesb.version>
         <bytebuddy.tesb.version>1.17.6</bytebuddy.tesb.version>
         <c3p0.tesb.version>0.12.0</c3p0.tesb.version>
         <commons-beanutils.tesb.version>1.11.0</commons-beanutils.tesb.version>
@@ -236,7 +236,7 @@
         <karaf-framework.tesb.version>4.4.6.20250901</karaf-framework.tesb.version>
         <kotlin.tesb.version>2.2.20</kotlin.tesb.version>
         <kotlin-stdlib-common.tesb.version>1.9.10</kotlin-stdlib-common.tesb.version>
-        <kudu.tesb.version>1.19.0.tesb2</kudu.tesb.version>
+        <kudu.tesb.version>1.19.0.tesb3</kudu.tesb.version>
         <langchain4j.tesb.version>1.6.0</langchain4j.tesb.version>
         <langchain4j-mcp.tesb.version>1.6.0-beta12</langchain4j-mcp.tesb.version>
         <logback.tesb.version>1.5.18</logback.tesb.version>
@@ -244,19 +244,22 @@
         <metrics.tesb.version>4.2.30</metrics.tesb.version>
         <micrometer.tesb.version>1.13.11</micrometer.tesb.version>
         <micrometer-tracing.tesb.version>1.3.9</micrometer-tracing.tesb.version>
-        <mina.tesb.version>2.2.4</mina.tesb.version>
+        <mina.tesb.version>2.2.7</mina.tesb.version>
         <minio.tesb.version>8.6.0</minio.tesb.version>
-        <netty.tesb.version>4.1.132.Final</netty.tesb.version>
+        <neethi.tesb.version>3.2.2</neethi.tesb.version>
+        <netty.tesb.version>4.1.133.Final</netty.tesb.version>
         <nimbus-jose-jwt.tesb.version>10.4</nimbus-jose-jwt.tesb.version>
         <oauth2-oidc-sdk.tesb.version>11.26</oauth2-oidc-sdk.tesb.version>
         <okhttp.tesb.version>5.3.2</okhttp.tesb.version>
         <okhttp4.tesb.version>4.12.0</okhttp4.tesb.version>
         <okio.tesb.version>3.16.2</okio.tesb.version>
-        <opennlp.tesb.version>2.5.4</opennlp.tesb.version>
+        <opennlp.tesb.version>2.5.9</opennlp.tesb.version>
+        <opentelemetry.tesb.version>1.62.0</opentelemetry.tesb.version>
+        <opentelemetry-instrumentation.tesb.version>2.27.0</opentelemetry-instrumentation.tesb.version>
         <paranamer.tesb.version>2.8</paranamer.tesb.version>
         <parquet-avro.tesb.version>1.15.2</parquet-avro.tesb.version>
         <pax-web.tesb.version>11.0.1</pax-web.tesb.version>
-        <pgjdbc-driver.tesb.version>42.7.7</pgjdbc-driver.tesb.version>
+        <pgjdbc-driver.tesb.version>42.7.11</pgjdbc-driver.tesb.version>
         <pooled-jms.tesb.version>3.1.7</pooled-jms.tesb.version>
         <proto-google-common-protos.tesb.version>2.59.2</proto-google-common-protos.tesb.version>
         <protobuf.tesb.version>3.25.5</protobuf.tesb.version>
@@ -269,15 +272,16 @@
         <slf4j.tesb.version>2.0.17</slf4j.tesb.version>
         <smallrye-fault-tolerance.tesb.version>6.9.0</smallrye-fault-tolerance.tesb.version>
         <snakeyaml.tesb.version>2.6</snakeyaml.tesb.version>
-        <spring.tesb.version>6.2.17</spring.tesb.version>
+        <spring.tesb.version>6.2.18</spring.tesb.version>
         <spring-batch.tesb.version>5.1.3</spring-batch.tesb.version>
         <spring-data-redis.tesb.version>3.3.10</spring-data-redis.tesb.version>
         <spring-ldap.tesb.version>3.2.11</spring-ldap.tesb.version>
         <spring-rabbit.tesb.version>3.2.5</spring-rabbit.tesb.version>
-        <spring-security.tesb.version>6.3.10</spring-security.tesb.version>
+        <spring-security.tesb.version>6.5.10</spring-security.tesb.version>
         <spring-ws.tesb.version>4.0.12</spring-ws.tesb.version>
         <squareup-okio.tesb.version>1.17.6</squareup-okio.tesb.version>
         <stax2-api.tesb.version>4.2.2</stax2-api.tesb.version>
+        <thymeleaf.tesb.version>3.1.5.RELEASE</thymeleaf.tesb.version>
         <tika.tesb.version>3.2.3</tika.tesb.version>
         <typesafe-config.tesb.version>1.4.2</typesafe-config.tesb.version>
         <undertow.tesb.version>2.3.22.Final</undertow.tesb.version>
@@ -1055,6 +1059,7 @@
                             <micrometer-tracing.tesb.version>${micrometer-tracing.tesb.version}</micrometer-tracing.tesb.version>
                             <mina.tesb.version>${mina.tesb.version}</mina.tesb.version>
                             <minio.tesb.version>${minio.tesb.version}</minio.tesb.version>
+                            <neethi.tesb.version>${neethi.tesb.version}</neethi.tesb.version>
                             <netty.tesb.version>${netty.tesb.version}</netty.tesb.version>
                             <nimbus-jose-jwt.tesb.version>${nimbus-jose-jwt.tesb.version}</nimbus-jose-jwt.tesb.version>
                             <oauth2-oidc-sdk.tesb.version>${oauth2-oidc-sdk.tesb.version}</oauth2-oidc-sdk.tesb.version>
@@ -1062,6 +1067,8 @@
                             <okhttp4.tesb.version>${okhttp4.tesb.version}</okhttp4.tesb.version>
                             <okio.tesb.version>${okio.tesb.version}</okio.tesb.version>
                             <opennlp.tesb.version>${opennlp.tesb.version}</opennlp.tesb.version>
+                            <opentelemetry.tesb.version>${opentelemetry.tesb.version}</opentelemetry.tesb.version>
+                            <opentelemetry-instrumentation.tesb.version>${opentelemetry-instrumentation.tesb.version}</opentelemetry-instrumentation.tesb.version>
                             <paranamer.tesb.version>${paranamer.tesb.version}</paranamer.tesb.version>
                             <parquet-avro.tesb.version>${parquet-avro.tesb.version}</parquet-avro.tesb.version>
                             <pax-web.tesb.version>${pax-web.tesb.version}</pax-web.tesb.version>
@@ -1086,6 +1093,7 @@
                             <spring-ws.tesb.version>${spring-ws.tesb.version}</spring-ws.tesb.version>
                             <squareup-okio.tesb.version>${squareup-okio.tesb.version}</squareup-okio.tesb.version>
                             <stax2-api.tesb.version>${stax2-api.tesb.version}</stax2-api.tesb.version>
+                            <thymeleaf.tesb.version>${thymeleaf.tesb.version}</thymeleaf.tesb.version>
                             <tika.tesb.version>${tika.tesb.version}</tika.tesb.version>
                             <typesafe-config.tesb.version>${typesafe-config.tesb.version}</typesafe-config.tesb.version>
                             <undertow.tesb.version>${undertow.tesb.version}</undertow.tesb.version>


### PR DESCRIPTION
CVE-2026-40490
-- async-http-client 2.12.4 -> 2.15.0

CVE-2026-3505,
CVE-2026-5588,
CVE-2026-5598,
CVE-2026-0636
-- bouncycastle 1.81 -> 1.84

CVE-2026-41409,
CVE-2026-41635,
CVE-2026-42778,
CVE-2026-42779
-- mina 2.2.4 -> 2.2.7

CVE-2026-42402,
CVE-2026-42403,
CVE-2026-42404
-- neethi 3.2.1 -> 3.2.2

CVE-2026-42583,
CVE-2026-42579,
CVE-2026-42584,
CVE-2026-42587,
CVE-2026-41417,
CVE-2026-42580,
CVE-2026-42581,
CVE-2026-42585
-- netty 4.1.132.Final -> netty 4.1.133.Final

CVE-2026-40682,
CVE-2026-42027,
CVE-2026-42440
-- opennlp 2.5.4 -> 2.5.9

CVE-2026-45292
-- opentelemetry 1.38.0, 1.43.0, 1.45.0 -> 1.62.0

CVE-2026-22745,
CVE-2026-22741
-- spring 6.2.17 -> 6.2.18

CVE-2026-22746,
CVE-2026-22748
-- spring-security 6.3.10 -> 6.5.10

CVE-2026-40477,
CVE-2026-40478,
CVE-2026-41901
-- thymeleaf 3.1.2.RESLEASE -> 3.1.5.RELEASE