### PR TITLE
fix(DPE-3122): can't access `http://localhost:8040/services`

### DIFF
--- a/components/camel-cxf/camel-cxf-all/src/main/java/org/apache/camel/component/cxf/transport/http/osgi/HTTPTransportActivator.java
+++ b/components/camel-cxf/camel-cxf-all/src/main/java/org/apache/camel/component/cxf/transport/http/osgi/HTTPTransportActivator.java
@@ -20,6 +20,7 @@ package org.apache.camel.component.cxf.transport.http.osgi;
 import jakarta.servlet.Servlet;
 import org.apache.cxf.common.util.CollectionUtils;
 import org.apache.cxf.common.util.PropertyUtils;
+import org.apache.cxf.transport.DestinationFactory;
 import org.apache.cxf.transport.http.DestinationRegistry;
 import org.apache.cxf.transport.http.DestinationRegistryImpl;
 import org.apache.cxf.transport.http.HTTPConduitConfigurer;
@@ -65,6 +66,8 @@ public class HTTPTransportActivator implements BundleActivator {
 
         context.registerService(DestinationRegistry.class.getName(), destinationRegistry, null);
         context.registerService(HTTPTransportFactory.class.getName(), transportFactory, null);
+        // Registers it also for the interface, as DestinationFactoryManagerImpl looks by DestinationFactory
+        context.registerService(DestinationFactory.class.getName(), transportFactory, null);
     }
 
     private <T> ServiceRegistration<T> registerService(BundleContext context, Class<T> serviceInterface,

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -134,20 +134,15 @@
 
     <feature name="jetty" version="${jetty11.tesb.version}">
         <feature version="[5,6)">jakarta-servlet</feature>
-        <bundle dependency="true">mvn:org.eclipse.jetty/jetty-alpn-server/${jetty11.tesb.version}</bundle>
         <bundle dependency="true">mvn:org.eclipse.jetty/jetty-http/${jetty11.tesb.version}</bundle>
         <bundle dependency="true">mvn:org.eclipse.jetty/jetty-io/${jetty11.tesb.version}</bundle>
         <bundle dependency="true">mvn:org.eclipse.jetty/jetty-server/${jetty11.tesb.version}</bundle>
         <bundle dependency="true">mvn:org.eclipse.jetty/jetty-util/${jetty11.tesb.version}</bundle>
         <bundle dependency="true">mvn:org.eclipse.jetty/jetty-security/${jetty11.tesb.version}</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty.http2/http2-hpack/${jetty11.tesb.version}</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty.http2/http2-common/${jetty11.tesb.version}</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty.http2/http2-server/${jetty11.tesb.version}</bundle>
     </feature>
 
     <feature name="jetty" version="${jetty12.tesb.version}">
         <feature version="[6,7)">jakarta-servlet</feature>
-        <bundle dependency="true">mvn:org.eclipse.jetty/jetty-alpn-server/${jetty12.tesb.version}</bundle>
         <bundle dependency="true">mvn:org.eclipse.jetty/jetty-http/${jetty12.tesb.version}</bundle>
         <bundle dependency="true">mvn:org.eclipse.jetty/jetty-io/${jetty12.tesb.version}</bundle>
         <bundle dependency="true">mvn:org.eclipse.jetty/jetty-server/${jetty12.tesb.version}</bundle>
@@ -155,9 +150,6 @@
         <bundle dependency="true">mvn:org.eclipse.jetty/jetty-jmx/${jetty12.tesb.version}</bundle>
         <bundle dependency="true">mvn:org.eclipse.jetty/jetty-util/${jetty12.tesb.version}</bundle>
         <bundle dependency="true">mvn:org.eclipse.jetty/jetty-security/${jetty12.tesb.version}</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty.http2/jetty-http2-hpack/${jetty12.tesb.version}</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty.http2/jetty-http2-common/${jetty12.tesb.version}</bundle>
-        <bundle dependency="true">mvn:org.eclipse.jetty.http2/jetty-http2-server/${jetty12.tesb.version}</bundle>
     </feature>
 
     <feature name="http-client" version="${httpclient4-version}">

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -3733,7 +3733,7 @@ Chain 2:
         <bundle dependency='true'>wrap:mvn:org.apache.zookeeper/zookeeper-jute/${zookeeper.tesb.version}$Bundle-SymbolicName=org.apache.zookeeper-jute&amp;Bundle-Version=${zookeeper.tesb.version}&amp;Export-Package=org.apache.*;version=${zookeeper.tesb.version}</bundle>
         <bundle dependency='true'>mvn:org.apache.curator/curator-client/${curator.tesb.version}</bundle>
         <bundle dependency='true'>mvn:org.apache.curator/curator-framework/${curator.tesb.version}</bundle>
-        <bundle dependency='true'>mvn:org.apache.curator/curator-recipes/${curator.tesb.version}</bundle>
+        <bundle dependency='true'>wrap:mvn:org.apache.curator/curator-recipes/${curator.tesb.version}$overwrite=merge&amp;Import-Package=!javax.annotation,!org.apache.curator.shaded.com.google*,com.google*;version="[33,34)",org.apache.curator*;version="[5.9,6)",*</bundle>
         <bundle dependency='true'>mvn:org.apache.curator/curator-x-discovery/${curator.tesb.version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-zookeeper/${upstream.version}</bundle>
     </feature>
@@ -3745,7 +3745,7 @@ Chain 2:
         <bundle dependency='true'>wrap:mvn:org.apache.zookeeper/zookeeper-jute/${zookeeper.tesb.version}$Bundle-SymbolicName=org.apache.zookeeper-jute&amp;Bundle-Version=${zookeeper.tesb.version}&amp;Export-Package=org.apache.*;version=${zookeeper.tesb.version}</bundle>
         <bundle dependency='true'>mvn:org.apache.curator/curator-client/${curator.tesb.version}</bundle>
         <bundle dependency='true'>mvn:org.apache.curator/curator-framework/${curator.tesb.version}</bundle>
-        <bundle dependency='true'>mvn:org.apache.curator/curator-recipes/${curator.tesb.version}</bundle>
+        <bundle dependency='true'>wrap:mvn:org.apache.curator/curator-recipes/${curator.tesb.version}$overwrite=merge&amp;Import-Package=!javax.annotation,!org.apache.curator.shaded.com.google*,com.google*;version="[33,34)",org.apache.curator*;version="[5.9,6)",*</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-zookeeper-master/${upstream.version}</bundle>
     </feature>
 </features>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -1227,7 +1227,7 @@
     </feature>
     <feature name='camel-docker' version='${upstream.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
-        <feature version='[32,33)'>guava</feature>
+        <feature version='[33,34)'>guava</feature>
         <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
         <feature version='[4.1,5)'>netty</feature>
         <!-- both 'docker-java' and 'docker-java-core' export 'com.github.dockerjava.core',


### PR DESCRIPTION
🏁 **Context**
- [DPE-3122](https://qlik-dev.atlassian.net/browse/DPE-3122)

🔍 **What is the problem this PR is trying to solve?**

🚀 **What is the chosen solution to this problem?**
~~https://github.com/jetty/jetty.project/issues/1894#issuecomment-336579567~~
Server side: remove http2 dependency from jetty

🎾 **Impacts**

- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR



[DPE-3122]: https://qlik-dev.atlassian.net/browse/DPE-3122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ