### PR TITLE
fix(DPE-2868): patch apache curator to avoid guava version conflict

### DIFF
--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -3736,24 +3736,24 @@ Chain 2:
     <feature name='camel-zookeeper' version='${upstream.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
-        <feature version="[32,33)">guava</feature>
+        <feature version="[33,34)">guava</feature>
         <bundle dependency='true'>wrap:mvn:org.apache.zookeeper/zookeeper/${zookeeper-server.tesb.version}$Bundle-SymbolicName=org.apache.zookeeper&amp;Bundle-Version=${zookeeper.tesb.version}&amp;Export-Package=org.apache.zookeeper*;version=${zookeeper.tesb.version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.apache.zookeeper/zookeeper-jute/${zookeeper.tesb.version}$Bundle-SymbolicName=org.apache.zookeeper-jute&amp;Bundle-Version=${zookeeper.tesb.version}&amp;Export-Package=org.apache.*;version=${zookeeper.tesb.version}</bundle>
-        <bundle dependency='true'>mvn:org.apache.curator/curator-client/${curator-version}/jar/osgi</bundle>
-        <bundle dependency='true'>mvn:org.apache.curator/curator-framework/${curator-version}/jar/osgi</bundle>
-        <bundle dependency='true'>wrap:mvn:org.apache.curator/curator-recipes/${curator-version}/jar/osgi$overwrite=merge&amp;Import-Package=javax.annotation;resolution:=optional,com.google*;version="[32,33)",org.apache.curator*;version="[5.9,6)",*</bundle>
-        <bundle dependency='true'>mvn:org.apache.curator/curator-x-discovery/${curator-version}/jar/osgi</bundle>
+        <bundle dependency='true'>mvn:org.apache.curator/curator-client/${curator.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.curator/curator-framework/${curator.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.curator/curator-recipes/${curator.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.curator/curator-x-discovery/${curator.tesb.version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-zookeeper/${upstream.version}</bundle>
     </feature>
     <feature name='camel-zookeeper-master' version='${upstream.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version='${camel-osgi-jackson2-version}'>jackson</feature>
-        <feature version="[32,33)">guava</feature>
+        <feature version="[33,34)">guava</feature>
         <bundle dependency='true'>wrap:mvn:org.apache.zookeeper/zookeeper/${zookeeper-server.tesb.version}$Bundle-SymbolicName=org.apache.zookeeper&amp;Bundle-Version=${zookeeper.tesb.version}&amp;Export-Package=org.apache.zookeeper*;version=${zookeeper.tesb.version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.apache.zookeeper/zookeeper-jute/${zookeeper.tesb.version}$Bundle-SymbolicName=org.apache.zookeeper-jute&amp;Bundle-Version=${zookeeper.tesb.version}&amp;Export-Package=org.apache.*;version=${zookeeper.tesb.version}</bundle>
-        <bundle dependency='true'>mvn:org.apache.curator/curator-client/${curator-version}/jar/osgi</bundle>
-        <bundle dependency='true'>mvn:org.apache.curator/curator-framework/${curator-version}/jar/osgi</bundle>
-        <bundle dependency='true'>wrap:mvn:org.apache.curator/curator-recipes/${curator-version}/jar/osgi$overwrite=merge&amp;Import-Package=javax.annotation;resolution:=optional,com.google*;version="[32,33)",org.apache.curator*;version="[5.9,6)",*</bundle>
+        <bundle dependency='true'>mvn:org.apache.curator/curator-client/${curator.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.curator/curator-framework/${curator.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.curator/curator-recipes/${curator.tesb.version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-zookeeper-master/${upstream.version}</bundle>
     </feature>
 </features>

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
         <camel-cxf-blueprint.tesb.version>4.18.1.20260401</camel-cxf-blueprint.tesb.version>
         <camel-cxf-transport-blueprint.tesb.version>4.18.1.20260401</camel-cxf-transport-blueprint.tesb.version>
         <camel-cxf-transport-jetty.tesb.version>4.18.1.20260401</camel-cxf-transport-jetty.tesb.version>
+        <curator.tesb.version>5.9.0.tesb1</curator.tesb.version>
         <zookeeper.tesb.version>3.9.5</zookeeper.tesb.version>
         <zookeeper-server.tesb.version>3.9.5.jetty12.1</zookeeper-server.tesb.version>
         <opensaml.bundle.tesb.version>5.1.4_1.tesb2</opensaml.bundle.tesb.version>
@@ -822,6 +823,9 @@
                             <upstream.version>${upstream.version}</upstream.version>
                             <camel-features.tesb.version>${camel-features.tesb.version}</camel-features.tesb.version>
                             <camel-spring.tesb.version>${camel-spring.tesb.version}</camel-spring.tesb.version>
+                            <curator.tesb.version>${curator.tesb.version}</curator.tesb.version>
+                            <zookeeper.tesb.version>${zookeeper.tesb.version}</zookeeper.tesb.version>
+                            <zookeeper-server.tesb.version>${zookeeper-server.tesb.version}</zookeeper-server.tesb.version>
                             <jetty11.tesb.version>${jetty11.tesb.version}</jetty11.tesb.version>
                             <jetty12.tesb.version>${jetty12.tesb.version}</jetty12.tesb.version>
                             <jetty.tesb.version>${jetty.tesb.version}</jetty.tesb.version>


### PR DESCRIPTION
🏁 **Context**
- [DPE-2868](https://qlik-dev.atlassian.net/browse/DPE-2868)

🔍 **What is the problem this PR is trying to solve?**

🚀 **What is the chosen solution to this problem?**

🎾 **Impacts**

- [ ] **This PR introduces a breaking change**

**Dear contributor, please check if the PR fulfills these requirements**

- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR


[DPE-2868]: https://qlik-dev.atlassian.net/browse/DPE-2868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ