### PR TITLE
DPE-3220 Backport security fixes from Camel 4.14.x.

### DIFF
--- a/Jenkinsfile.talend
+++ b/Jenkinsfile.talend
@@ -21,10 +21,13 @@ org.apache.camel.karaf:camel-vm,\
 \
 org.apache.camel.karaf:camel-activemq,\
 org.apache.camel.karaf:camel-activemq6,\
+org.apache.camel.karaf:camel-amqp,\
 org.apache.camel.karaf:camel-as2,\
 org.apache.camel.karaf:camel-aws2-kinesis,\
 org.apache.camel.karaf:camel-aws2-s3,\
 org.apache.camel.karaf:camel-aws2-sqs,\
+org.apache.camel.karaf:camel-coap,\
+org.apache.camel.karaf:camel-consul,\
 org.apache.camel.karaf:camel-crypto,\
 org.apache.camel.karaf:camel-cxf-all,\
 org.apache.camel.karaf:camel-cxf-blueprint,\
@@ -42,8 +45,11 @@ org.apache.camel.karaf:camel-direct,\
 org.apache.camel.karaf:camel-drill,\
 org.apache.camel.karaf:camel-dynamic-router,\
 org.apache.camel.karaf:camel-file,\
+org.apache.camel.karaf:camel-google-pubsub,\
 org.apache.camel.karaf:camel-http,\
+org.apache.camel.karaf:camel-infinispan,\
 org.apache.camel.karaf:camel-jaxb,\
+org.apache.camel.karaf:camel-jms,\
 org.apache.camel.karaf:camel-jsonpath,\
 org.apache.camel.karaf:camel-knative-http,\
 org.apache.camel.karaf:camel-kubernetes,\
@@ -51,6 +57,7 @@ org.apache.camel.karaf:camel-langchain4j-core,\
 org.apache.camel.karaf:camel-langchain4j-chat,\
 org.apache.camel.karaf:camel-langchain4j-tools,\
 org.apache.camel.karaf:camel-leveldb,\
+org.apache.camel.karaf:camel-mail,\
 org.apache.camel.karaf:camel-mina,\
 org.apache.camel.karaf:camel-minio,\
 org.apache.camel.karaf:camel-mongodb,\
@@ -61,6 +68,8 @@ org.apache.camel.karaf:camel-quartz,\
 org.apache.camel.karaf:camel-ref,\
 org.apache.camel.karaf:camel-rest-openapi,\
 org.apache.camel.karaf:camel-salesforce,\
+org.apache.camel.karaf:camel-sjms,\
+org.apache.camel.karaf:camel-sjms2,\
 org.apache.camel.karaf:camel-smb,\
 org.apache.camel.karaf:camel-spring,\
 org.apache.camel.karaf:camel-sql,\

--- a/components/camel-amqp/pom.xml
+++ b/components/camel-amqp/pom.xml
@@ -31,8 +31,10 @@
     <artifactId>camel-amqp</artifactId>
     <packaging>bundle</packaging>
     <name>Apache Camel :: Karaf :: Components :: AMQP</name>
+    <version>${revision}</version>
 
     <properties>
+        <revision>${camel-amqp.tesb.version}</revision>
         <camel.osgi.export>
             org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
@@ -45,7 +47,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-amqp</artifactId>
-            <version>${camel-version}</version>
+            <version>${camel-amqp.tesb.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-coap/pom.xml
+++ b/components/camel-coap/pom.xml
@@ -31,8 +31,10 @@
     <artifactId>camel-coap</artifactId>
     <packaging>bundle</packaging>
     <name>Apache Camel :: Karaf :: Components :: CoAP</name>
+    <version>${revision}</version>
 
     <properties>
+        <revision>${camel-coap.tesb.version}</revision>
         <camel.osgi.export>
             org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
@@ -45,7 +47,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-coap</artifactId>
-            <version>${camel-version}</version>
+            <version>${camel-coap.tesb.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-consul/pom.xml
+++ b/components/camel-consul/pom.xml
@@ -31,8 +31,10 @@
     <artifactId>camel-consul</artifactId>
     <packaging>bundle</packaging>
     <name>Apache Camel :: Karaf :: Components :: Consul</name>
+    <version>${revision}</version>
 
     <properties>
+        <revision>${camel-consul.tesb.version}</revision>
         <camel.osgi.export>
             org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
@@ -45,7 +47,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-consul</artifactId>
-            <version>${camel-version}</version>
+            <version>${camel-consul.tesb.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-cxf/camel-cxf-all/pom.xml
+++ b/components/camel-cxf/camel-cxf-all/pom.xml
@@ -353,7 +353,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-cxf-transport</artifactId>
-            <version>${camel-cxf.tesb.version}</version>
+            <version>${camel-cxf-transport.tesb.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-cxf/camel-cxf-transport-blueprint/pom.xml
+++ b/components/camel-cxf/camel-cxf-transport-blueprint/pom.xml
@@ -33,7 +33,7 @@
     <version>${revision}</version>
 
     <properties>
-        <revision>${camel-cxf.tesb.version}</revision>
+        <revision>${camel-cxf-transport.tesb.version}</revision>
         <firstVersion>3.2.0</firstVersion>
         <camel.osgi.export>
             org.apache.camel.component.cxf.transport.blueprint;version=${upstream.version},
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-cxf-transport</artifactId>
-            <version>${camel-cxf.tesb.version}</version>
+            <version>${camel-cxf-transport.tesb.version}</version>
         </dependency>
 
         <!-- OSGi, Blueprint -->

--- a/components/camel-google/camel-google-pubsub/pom.xml
+++ b/components/camel-google/camel-google-pubsub/pom.xml
@@ -31,8 +31,10 @@
     <artifactId>camel-google-pubsub</artifactId>
     <packaging>bundle</packaging>
     <name>Apache Camel :: Karaf :: Components :: Google :: PubSub</name>
+    <version>${revision}</version>
 
     <properties>
+        <revision>${camel-google-pubsub.tesb.version}</revision>
         <camel.osgi.export>
             org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
@@ -49,7 +51,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-google-pubsub</artifactId>
-            <version>${camel-version}</version>
+            <version>${camel-google-pubsub.tesb.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-infinispan/camel-infinispan/pom.xml
+++ b/components/camel-infinispan/camel-infinispan/pom.xml
@@ -31,8 +31,10 @@
     <artifactId>camel-infinispan</artifactId>
     <packaging>bundle</packaging>
     <name>Apache Camel :: Karaf :: Components :: Infinispan :: Infinispan</name>
+    <version>${revision}</version>
 
     <properties>
+        <revision>${camel-infinispan.tesb.version}</revision>
         <camel.osgi.export>
             org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
@@ -46,7 +48,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-infinispan</artifactId>
-            <version>${camel-version}</version>
+            <version>${camel-infinispan.tesb.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-jms/pom.xml
+++ b/components/camel-jms/pom.xml
@@ -31,8 +31,10 @@
     <artifactId>camel-jms</artifactId>
     <packaging>bundle</packaging>
     <name>Apache Camel :: Karaf :: Components :: JMS</name>
+    <version>${revision}</version>
 
     <properties>
+        <revision>${camel-jms.tesb.version}</revision>
         <camel.osgi.export>
             org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
@@ -46,7 +48,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-jms</artifactId>
-            <version>${camel-version}</version>
+            <version>${camel-jms.tesb.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-mail/pom.xml
+++ b/components/camel-mail/pom.xml
@@ -31,8 +31,10 @@
     <artifactId>camel-mail</artifactId>
     <packaging>bundle</packaging>
     <name>Apache Camel :: Karaf :: Components :: Mail</name>
+    <version>${revision}</version>
 
     <properties>
+        <revision>${camel-mail.tesb.version}</revision>
         <camel.osgi.export>
             org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
@@ -46,7 +48,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-mail</artifactId>
-            <version>${camel-version}</version>
+            <version>${camel-mail.tesb.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-sjms/pom.xml
+++ b/components/camel-sjms/pom.xml
@@ -31,8 +31,10 @@
     <artifactId>camel-sjms</artifactId>
     <packaging>bundle</packaging>
     <name>Apache Camel :: Karaf :: Components :: Simple JMS</name>
+    <version>${revision}</version>
 
     <properties>
+        <revision>${camel-sjms.tesb.version}</revision>
         <camel.osgi.export>
             org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
@@ -45,7 +47,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-sjms</artifactId>
-            <version>${camel-version}</version>
+            <version>${camel-sjms.tesb.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/components/camel-sjms2/pom.xml
+++ b/components/camel-sjms2/pom.xml
@@ -31,8 +31,10 @@
     <artifactId>camel-sjms2</artifactId>
     <packaging>bundle</packaging>
     <name>Apache Camel :: Karaf :: Components :: Simple JMS2</name>
+    <version>${revision}</version>
 
     <properties>
+        <revision>${camel-sjms2.tesb.version}</revision>
         <camel.osgi.export>
             org.apache.camel*;version=${camel-version}
         </camel.osgi.export>
@@ -45,7 +47,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-sjms2</artifactId>
-            <version>${camel-version}</version>
+            <version>${camel-sjms2.tesb.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.camel</groupId>

--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -394,7 +394,7 @@
         <bundle dependency='true'>mvn:org.apache.qpid/proton-j/${qpid-proton-j-version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-codec-http/${netty.tesb.version}</bundle>
         <bundle dependency='true'>mvn:io.netty/netty-transport-classes-epoll/${netty.tesb.version}</bundle>
-        <bundle>mvn:org.apache.camel.karaf/camel-amqp/${upstream.version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-amqp/${camel-amqp.tesb.version}</bundle>
     </feature>
 
     <feature name='camel-arangodb' version='${upstream.version}' start-level='50'>
@@ -892,7 +892,7 @@
         <bundle dependency='true'>wrap:mvn:org.eclipse.californium/element-connector/${californium-version}$overwrite=merge&amp;Import-Package=net.i2p.crypto.eddsa;resolution:=optional,*;resolution:=optional</bundle>
         <bundle dependency='true'>mvn:org.eclipse.californium/element-connector-tcp-netty/${californium-version}</bundle>
         <bundle dependency='true'>mvn:org.eclipse.californium/scandium/${californium-scandium-version}</bundle>
-        <bundle>mvn:org.apache.camel.karaf/camel-coap/${upstream.version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-coap/${camel-coap.tesb.version}</bundle>
     </feature>
     <feature name='camel-cometd' version='${upstream.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
@@ -923,7 +923,7 @@
         <bundle dependency='true'>mvn:com.fasterxml.jackson.datatype/jackson-datatype-jdk8/${jackson2.tesb.version}</bundle>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.datatype/jackson-datatype-guava/${jackson2.tesb.version}</bundle>
         <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3.tesb.version}</bundle>
-        <bundle>mvn:org.apache.camel.karaf/camel-consul/${upstream.version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-consul/${camel-consul.tesb.version}</bundle>
     </feature>
     <feature name='camel-couchbase' version='${upstream.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
@@ -994,7 +994,7 @@
         <bundle>mvn:org.apache.camel.karaf/camel-http-common/${upstream.version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-cxf-all/${camel-cxf-all.tesb.version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-cxf-blueprint/${camel-cxf.tesb.version}</bundle>
-        <bundle>mvn:org.apache.camel.karaf/camel-cxf-transport-blueprint/${camel-cxf.tesb.version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-cxf-transport-blueprint/${camel-cxf-transport.tesb.version}</bundle>
     </feature>
     <feature name='camel-cxf-jetty' version='${upstream.version}' start-level='50'>
         <feature version="[12,13)">jetty</feature>
@@ -1434,7 +1434,7 @@
         <bundle dependency='true'>wrap:mvn:io.grpc/grpc-auth/${grpc.tesb.version}</bundle>
         <bundle dependency='true'>wrap:mvn:io.grpc/grpc-util/${grpc.tesb.version}</bundle>
         <bundle dependency='true'>mvn:com.google.code.findbugs/jsr305/${jsr305.tesb.version}</bundle>
-        <bundle>mvn:org.apache.camel.karaf/camel-google-pubsub/${upstream.version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-google-pubsub/${camel-google-pubsub.tesb.version}</bundle>
     </feature>
     <feature name='camel-google-pubsub-lite' version='${upstream.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
@@ -1695,7 +1695,7 @@
         <feature version='${camel-osgi-version-range}'>camel-infinispan-common</feature>
         <bundle dependency='true'>wrap:mvn:org.infinispan/infinispan-client-hotrod/${infinispan.tesb.version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.infinispan/infinispan-remote-query-client/${infinispan.tesb.version}</bundle>
-        <bundle>mvn:org.apache.camel.karaf/camel-infinispan/${upstream.version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-infinispan/${camel-infinispan.tesb.version}</bundle>
     </feature>
     <feature name='camel-infinispan-common' version='${upstream.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
@@ -1868,7 +1868,7 @@
     <feature name="camel-jms" version="${upstream.version}" start-level="50">
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <feature version="${camel-osgi-spring-version}">spring-jms</feature>
-        <bundle>mvn:org.apache.camel.karaf/camel-jms/${upstream.version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-jms/${camel-jms.tesb.version}</bundle>
     </feature>
     <feature name='camel-jmx' version='${upstream.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
@@ -2169,7 +2169,7 @@
         <!-- <bundle dependency='true'>wrap:mvn:org.eclipse.angus/angus-mail/${angus-mail.tesb.version}$overwrite=merge</bundle> -->
         <bundle dependency='true'>wrap:mvn:org.eclipse.angus/jakarta.mail/${angus-mail.tesb.version}$overwrite=merge</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-attachments/${upstream.version}</bundle>
-        <bundle>mvn:org.apache.camel.karaf/camel-mail/${upstream.version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-mail/${camel-mail.tesb.version}</bundle>
     </feature>
     <feature name='camel-mail-microsoft-oauth' version='${upstream.version}' start-level='50'>
         <feature version='[${azure-core-version},2)'>azure-msal4j</feature>
@@ -2818,11 +2818,11 @@
     <feature name='camel-sjms' version='${upstream.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency="true">mvn:jakarta.jms/jakarta.jms-api/${jakarta-jms-api-version}</bundle>
-        <bundle>mvn:org.apache.camel.karaf/camel-sjms/${upstream.version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-sjms/${camel-sjms.tesb.version}</bundle>
     </feature>
     <feature name='camel-sjms2' version='${upstream.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-sjms</feature>
-        <bundle>mvn:org.apache.camel.karaf/camel-sjms2/${upstream.version}</bundle>
+        <bundle>mvn:org.apache.camel.karaf/camel-sjms2/${camel-sjms2.tesb.version}</bundle>
     </feature>
     <feature name='camel-slack' version='${upstream.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>

--- a/pom.xml
+++ b/pom.xml
@@ -88,15 +88,16 @@
     <!-- TODO use Karaf/Camel bom -->
     <properties>
         <upstream.version>4.8.1</upstream.version>
-        <camel-features.tesb.version>4.8.1.20260512</camel-features.tesb.version>
+        <camel-features.tesb.version>4.8.1.20260608</camel-features.tesb.version>
         <camel-support.tesb.version>4.8.1.20260120</camel-support.tesb.version>
         <camel-vm.tesb.version>4.8.1.20250320</camel-vm.tesb.version>
-        <camel-activemq.tesb.version>4.8.1.20250320</camel-activemq.tesb.version>
-        <camel-activemq6.tesb.version>4.8.1.20250320</camel-activemq6.tesb.version>
+        <camel-activemq.tesb.version>4.8.1.20260608</camel-activemq.tesb.version>
+        <camel-activemq6.tesb.version>4.8.1.20260608</camel-activemq6.tesb.version>
         <camel-cxf.tesb.version>4.8.1.20251008</camel-cxf.tesb.version>
-        <camel-cxf-all.tesb.version>4.8.1.20251204</camel-cxf-all.tesb.version>
+        <camel-cxf-all.tesb.version>4.8.1.20260608</camel-cxf-all.tesb.version>
         <camel-cxf-soap.tesb.version>4.8.1.20250320</camel-cxf-soap.tesb.version>
-        <camel-cxf-rest.tesb.version>4.8.1.20250320</camel-cxf-rest.tesb.version>
+        <camel-cxf-rest.tesb.version>4.8.1.20260608</camel-cxf-rest.tesb.version>
+        <camel-cxf-transport.tesb.version>4.8.1.20260608</camel-cxf-transport.tesb.version>
         <camel-cxf-transport-jetty.tesb.version>4.8.1.20260323</camel-cxf-transport-jetty.tesb.version>
         <camel-spring.tesb.version>4.8.1.20250320</camel-spring.tesb.version>
         <camel-blueprint.tesb.version>4.8.1.20250320</camel-blueprint.tesb.version>
@@ -104,14 +105,15 @@
         <camel-langchain4j-chat.tesb.version>4.8.1.20251119</camel-langchain4j-chat.tesb.version>
         <camel-langchain4j-core.tesb.version>4.8.1.20251119</camel-langchain4j-core.tesb.version>
         <camel-langchain4j-tools.tesb.version>4.8.1.20251119</camel-langchain4j-tools.tesb.version>
+        <camel-amqp.tesb.version>4.8.1.20260608</camel-amqp.tesb.version>
         <camel-as2-api.tesb.version>4.8.1.20250320</camel-as2-api.tesb.version>
         <camel-as2.tesb.version>4.8.1.20250320</camel-as2.tesb.version>
         <camel-aws2-kinesis.tesb.version>4.8.1.20250320</camel-aws2-kinesis.tesb.version>
         <camel-aws2-s3.tesb.version>4.8.1.20250320</camel-aws2-s3.tesb.version>
         <camel-aws2-sqs.tesb.version>4.8.1.20250320</camel-aws2-sqs.tesb.version>
+        <camel-coap.tesb.version>4.8.1.20260608</camel-coap.tesb.version>
+        <camel-consul.tesb.version>4.8.1.20260608</camel-consul.tesb.version>
         <camel-crypto.tesb.version>4.8.1.20250320</camel-crypto.tesb.version>
-        <!-- <camel-cxf-rest.tesb.version>4.8.1.20250320</camel-cxf-rest.tesb.version> -->
-        <!-- <camel-cxf-soap.tesb.version>4.8.1.20250320</camel-cxf-soap.tesb.version> -->
         <camel-debezium-common.tesb.version>4.8.1.20250320</camel-debezium-common.tesb.version>
         <camel-debezium-db2.tesb.version>4.8.1.20250320</camel-debezium-db2.tesb.version>
         <camel-debezium-mongodb.tesb.version>4.8.1.20250320</camel-debezium-mongodb.tesb.version>
@@ -123,13 +125,17 @@
         <camel-drill.tesb.version>4.8.1.20250901</camel-drill.tesb.version>
         <camel-dynamic-router.tesb.version>4.8.1.20250320</camel-dynamic-router.tesb.version>
         <camel-file.tesb.version>4.8.1.20250320</camel-file.tesb.version>
+        <camel-google-pubsub.tesb.version>4.8.1.20260608</camel-google-pubsub.tesb.version>
         <camel-http.tesb.version>4.8.1.20250320</camel-http.tesb.version>
+        <camel-infinispan.tesb.version>4.8.1.20260608</camel-infinispan.tesb.version>
         <camel-jaxb.tesb.version>4.8.1.20250320</camel-jaxb.tesb.version>
+        <camel-jms.tesb.version>4.8.1.20260608</camel-jms.tesb.version>
         <camel-jsonpath.tesb.version>4.8.1.20250320</camel-jsonpath.tesb.version>
         <camel-knative-http.tesb.version>4.8.1.20250320</camel-knative-http.tesb.version>
         <camel-kubernetes.tesb.version>4.8.1.20250320</camel-kubernetes.tesb.version>
         <camel-leveldb.tesb.version>4.8.1.20260304</camel-leveldb.tesb.version>
-        <camel-mina.tesb.version>4.8.1.20250320</camel-mina.tesb.version>
+        <camel-mail.tesb.version>4.8.1.20260608</camel-mail.tesb.version>
+        <camel-mina.tesb.version>4.8.1.20260608</camel-mina.tesb.version>
         <camel-minio.tesb.version>4.8.1.20250320</camel-minio.tesb.version>
         <camel-mongodb.tesb.version>4.8.1.20250320</camel-mongodb.tesb.version>
         <camel-observation.tesb.version>4.8.1.20250320</camel-observation.tesb.version>
@@ -139,6 +145,8 @@
         <camel-ref.tesb.version>4.8.1.20250320</camel-ref.tesb.version>
         <camel-rest-openapi.tesb.version>4.8.1.20250320</camel-rest-openapi.tesb.version>
         <camel-salesforce.tesb.version>4.8.1.20251213</camel-salesforce.tesb.version>
+        <camel-sjms.tesb.version>4.8.1.20260608</camel-sjms.tesb.version>
+        <camel-sjms2.tesb.version>4.8.1.20260608</camel-sjms2.tesb.version>
         <camel-smb.tesb.version>4.8.1.20250320</camel-smb.tesb.version>
         <camel-sql.tesb.version>4.8.1.20250320</camel-sql.tesb.version>
         <camel-tika.tesb.version>4.8.1.20251208</camel-tika.tesb.version>
@@ -913,20 +921,22 @@
                             <camel-cxf-all.tesb.version>${camel-cxf-all.tesb.version}</camel-cxf-all.tesb.version>
                             <camel-cxf-soap.tesb.version>${camel-cxf-soap.tesb.version}</camel-cxf-soap.tesb.version>
                             <camel-cxf-rest.tesb.version>${camel-cxf-rest.tesb.version}</camel-cxf-rest.tesb.version>
+                            <camel-cxf-transport.tesb.version>${camel-cxf-transport.tesb.version}</camel-cxf-transport.tesb.version>
                             <camel-cxf-transport-jetty.tesb.version>${camel-cxf-transport-jetty.tesb.version}</camel-cxf-transport-jetty.tesb.version>
                             <camel-spring.tesb.version>${camel-spring.tesb.version}</camel-spring.tesb.version>
                             <camel-tooling.tesb.version>${camel-tooling.tesb.version}</camel-tooling.tesb.version>
                             <camel-langchain4j-chat.tesb.version>${camel-langchain4j-chat.tesb.version}</camel-langchain4j-chat.tesb.version>
                             <camel-langchain4j-core.tesb.version>${camel-langchain4j-core.tesb.version}</camel-langchain4j-core.tesb.version>
                             <camel-langchain4j-tools.tesb.version>${camel-langchain4j-tools.tesb.version}</camel-langchain4j-tools.tesb.version>
+                            <camel-amqp.tesb.version>${camel-amqp.tesb.version}</camel-amqp.tesb.version>
                             <camel-as2-api.tesb.version>${camel-as2-api.tesb.version}</camel-as2-api.tesb.version>
                             <camel-as2.tesb.version>${camel-as2.tesb.version}</camel-as2.tesb.version>
                             <camel-aws2-kinesis.tesb.version>${camel-aws2-kinesis.tesb.version}</camel-aws2-kinesis.tesb.version>
                             <camel-aws2-s3.tesb.version>${camel-aws2-s3.tesb.version}</camel-aws2-s3.tesb.version>
                             <camel-aws2-sqs.tesb.version>${camel-aws2-sqs.tesb.version}</camel-aws2-sqs.tesb.version>
+                            <camel-coap.tesb.version>${camel-coap.tesb.version}</camel-coap.tesb.version>
+                            <camel-consul.tesb.version>${camel-consul.tesb.version}</camel-consul.tesb.version>
                             <camel-crypto.tesb.version>${camel-crypto.tesb.version}</camel-crypto.tesb.version>
-                            <!-- <camel-cxf-rest.tesb.version>${camel-cxf-rest.tesb.version}</camel-cxf-rest.tesb.version> -->
-                            <!-- <camel-cxf-soap.tesb.version>${camel-cxf-soap.tesb.version}</camel-cxf-soap.tesb.version> -->
                             <camel-debezium-common.tesb.version>${camel-debezium-common.tesb.version}</camel-debezium-common.tesb.version>
                             <camel-debezium-db2.tesb.version>${camel-debezium-db2.tesb.version}</camel-debezium-db2.tesb.version>
                             <camel-debezium-mongodb.tesb.version>${camel-debezium-mongodb.tesb.version}</camel-debezium-mongodb.tesb.version>
@@ -938,12 +948,16 @@
                             <camel-drill.tesb.version>${camel-drill.tesb.version}</camel-drill.tesb.version>
                             <camel-dynamic-router.tesb.version>${camel-dynamic-router.tesb.version}</camel-dynamic-router.tesb.version>
                             <camel-file.tesb.version>${camel-file.tesb.version}</camel-file.tesb.version>
+                            <camel-google-pubsub.tesb.version>${camel-google-pubsub.tesb.version}</camel-google-pubsub.tesb.version>
                             <camel-http.tesb.version>${camel-http.tesb.version}</camel-http.tesb.version>
+                            <camel-infinispan.tesb.version>${camel-infinispan.tesb.version}</camel-infinispan.tesb.version>
                             <camel-jaxb.tesb.version>${camel-jaxb.tesb.version}</camel-jaxb.tesb.version>
+                            <camel-jms.tesb.version>${camel-jms.tesb.version}</camel-jms.tesb.version>
                             <camel-jsonpath.tesb.version>${camel-jsonpath.tesb.version}</camel-jsonpath.tesb.version>
                             <camel-knative-http.tesb.version>${camel-knative-http.tesb.version}</camel-knative-http.tesb.version>
                             <camel-kubernetes.tesb.version>${camel-kubernetes.tesb.version}</camel-kubernetes.tesb.version>
                             <camel-leveldb.tesb.version>${camel-leveldb.tesb.version}</camel-leveldb.tesb.version>
+                            <camel-mail.tesb.version>${camel-mail.tesb.version}</camel-mail.tesb.version>
                             <camel-mina.tesb.version>${camel-mina.tesb.version}</camel-mina.tesb.version>
                             <camel-minio.tesb.version>${camel-minio.tesb.version}</camel-minio.tesb.version>
                             <camel-mongodb.tesb.version>${camel-mongodb.tesb.version}</camel-mongodb.tesb.version>
@@ -954,6 +968,8 @@
                             <camel-ref.tesb.version>${camel-ref.tesb.version}</camel-ref.tesb.version>
                             <camel-rest-openapi.tesb.version>${camel-rest-openapi.tesb.version}</camel-rest-openapi.tesb.version>
                             <camel-salesforce.tesb.version>${camel-salesforce.tesb.version}</camel-salesforce.tesb.version>
+                            <camel-sjms.tesb.version>${camel-sjms.tesb.version}</camel-sjms.tesb.version>
+                            <camel-sjms2.tesb.version>${camel-sjms2.tesb.version}</camel-sjms2.tesb.version>
                             <camel-smb.tesb.version>${camel-smb.tesb.version}</camel-smb.tesb.version>
                             <camel-sql.tesb.version>${camel-sql.tesb.version}</camel-sql.tesb.version>
                             <camel-tika.tesb.version>${camel-tika.tesb.version}</camel-tika.tesb.version>


### PR DESCRIPTION
CVE-2026-40453 camel-coap backport from 4.14.6
CVE-2026-33454 camel-mail backport from 4.14.6
CVE-2026-27172 camel-consul from 4.14.6
CVE-2026-40453 camel-google-pubsub from 4.14.6
CVE-2026-40453 camel-jms from 4.14.6
CVE-2026-40453 camel-sjms from 4.14.6
CVE-2026-40473 camel-mina from 4.14.6
CVE-2026-47323 camel-cxf-rest, camel-cxf-transport, camel-knative-http from 4.14.6
CVE-2026-40860 camel-jms, camel-sjms, camel-sjms2, camel-amqp, camel-activemq, camel-activemq6 from 4.14.7
CVE-2026-40858 camel-infinispan from 4.14.7