### PR TITLE
DPE-3427 Security updates for TESB R2026-07.

### DIFF
--- a/features/src/main/feature/camel-features.xml
+++ b/features/src/main/feature/camel-features.xml
@@ -140,7 +140,7 @@
     </feature>
 
     <feature name="jackson" version="${jackson2.tesb.version}">
-        <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2.tesb.version}.spiprov</bundle>
+        <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-databind/${jackson2-databind.tesb.version}.spiprov</bundle>
         <!-- wrap needed to add the missing SPI-Provider clause to the manifest -->
         <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-core/${jackson2.tesb.version}.spiprov</bundle>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.core/jackson-annotations/${jackson2-annotations.tesb.version}</bundle>
@@ -900,13 +900,13 @@
         <feature version="${jetty12.tesb.version-range}">jetty</feature>
         <bundle dependency='true'>mvn:org.eclipse.jetty.ee10/jetty-ee10-servlet/${jetty12.tesb.version}</bundle>
         <bundle dependency='true'>mvn:org.eclipse.jetty.ee10/jetty-ee10-servlets/${jetty12.tesb.version}</bundle>
-        <bundle dependency='true'>mvn:org.cometd.java/cometd-java-server-common/${cometd-java-server-version}</bundle>
-        <bundle dependency='true'>mvn:org.cometd.java/cometd-java-server-http-jakarta/${cometd-java-server-version}</bundle>
-        <bundle dependency='true'>mvn:org.cometd.java/cometd-java-server-websocket-jetty/${cometd-java-server-version}</bundle>
-        <bundle dependency='true'>mvn:org.cometd.java/cometd-java-common/${cometd-java-server-version}</bundle>
-        <bundle dependency='true'>mvn:org.cometd.java/cometd-java-api-server/${cometd-java-server-version}</bundle>
-        <bundle dependency='true'>mvn:org.cometd.java/cometd-java-api-common/${cometd-java-server-version}</bundle>
-        <bundle dependency='true'>mvn:org.cometd.java/cometd-java-api-client/${cometd-java-server-version}</bundle>
+        <bundle dependency='true'>mvn:org.cometd.java/cometd-java-server-common/${cometd-java-server.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:org.cometd.java/cometd-java-server-http-jakarta/${cometd-java-server.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:org.cometd.java/cometd-java-server-websocket-jetty/${cometd-java-server.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:org.cometd.java/cometd-java-common/${cometd-java-server.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:org.cometd.java/cometd-java-api-server/${cometd-java-server.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:org.cometd.java/cometd-java-api-common/${cometd-java-server.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:org.cometd.java/cometd-java-api-client/${cometd-java-server.tesb.version}</bundle>
         <bundle dependency="true">mvn:org.eclipse.jetty/jetty-util-ajax/${jetty.tesb.version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-cometd/${upstream.version}</bundle>
     </feature>
@@ -2114,23 +2114,25 @@
     </feature>
     <feature name='camel-ldif' version='${upstream.version}' start-level='50'>
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
-        <bundle dependency='true'>mvn:org.apache.directory.api/api-i18n/${auto-detect-version}</bundle>
-        <bundle dependency='true'>mvn:org.apache.directory.api/api-asn1-api/${auto-detect-version}</bundle>
-        <bundle dependency='true'>mvn:org.apache.directory.api/api-asn1-ber/${auto-detect-version}</bundle>
-        <bundle dependency='true'>mvn:org.apache.directory.api/api-ldap-client-api/${auto-detect-version}</bundle>
-        <bundle dependency='true'>mvn:org.apache.directory.api/api-ldap-codec-core/${auto-detect-version}</bundle>
-        <bundle dependency='true'>mvn:org.apache.directory.api/api-ldap-extras-aci/${auto-detect-version}</bundle>
-        <bundle dependency='true'>mvn:org.apache.directory.api/api-ldap-extras-codec/${auto-detect-version}</bundle>
-        <bundle dependency='true'>mvn:org.apache.directory.api/api-ldap-extras-codec-api/${auto-detect-version}</bundle>
-        <bundle dependency='true'>mvn:org.apache.directory.api/api-ldap-model/${auto-detect-version}</bundle>
-        <bundle dependency='true'>mvn:org.apache.directory.api/api-ldap-schema-data/${auto-detect-version}</bundle>
-        <bundle dependency='true'>mvn:org.apache.directory.api/api-util/${auto-detect-version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.directory.api/api-i18n/${apache-directory-api.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.directory.api/api-asn1-api/${apache-directory-api.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.directory.api/api-asn1-ber/${apache-directory-api.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.directory.api/api-ldap-client-api/${apache-directory-api.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.directory.api/api-ldap-codec-core/${apache-directory-api.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.directory.api/api-ldap-extras-aci/${apache-directory-api.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.directory.api/api-ldap-extras-codec/${apache-directory-api.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.directory.api/api-ldap-extras-codec-api/${apache-directory-api.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.directory.api/api-ldap-model/${apache-directory-api.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.directory.api/api-ldap-schema-data/${apache-directory-api.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.directory.api/api-util/${apache-directory-api.tesb.version}</bundle>
         <bundle dependency='true'>mvn:org.apache.directory.server/apacheds-core-api/${apacheds-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.antlr/${auto-detect-version}</bundle>
         <bundle dependency='true'>mvn:org.apache.commons/commons-collections4/${commons-collections4.tesb.version}</bundle>
         <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3.tesb.version}</bundle>
         <bundle dependency='true'>mvn:org.apache.commons/commons-pool2/${commons-pool2.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:org.apache.commons/commons-text/${commons-text.tesb.version}</bundle>
         <bundle dependency='true'>mvn:org.apache.mina/mina-core/${mina.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:com.github.ben-manes.caffeine/caffeine/${auto-detect-version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-ldif/${upstream.version}</bundle>
     </feature>
     <feature name='camel-leveldb' version='${upstream.version}' start-level='50'>
@@ -2742,12 +2744,12 @@
         <bundle dependency='true'>mvn:org.apache.commons/commons-compress/${commons-compress.tesb.version}</bundle>
         <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io.tesb.version}</bundle>
         <bundle dependency='true'>mvn:org.apache.commons/commons-lang3/${commons-lang3.tesb.version}</bundle>
-        <bundle dependency='true'>mvn:org.cometd.java/cometd-java-api-common/${cometd-java-client-version}</bundle>
-        <bundle dependency='true'>mvn:org.cometd.java/cometd-java-api-client/${cometd-java-client-version}</bundle>
-        <bundle dependency='true'>mvn:org.cometd.java/cometd-java-client-common/${cometd-java-client-version}</bundle>
-        <bundle dependency='true'>mvn:org.cometd.java/cometd-java-client-http-jetty/${cometd-java-client-version}</bundle>
-        <bundle dependency='true'>mvn:org.cometd.java/cometd-java-client-http-common/${cometd-java-client-version}</bundle>
-        <bundle dependency='true'>mvn:org.cometd.java/cometd-java-common/${cometd-java-client-version}</bundle>
+        <bundle dependency='true'>mvn:org.cometd.java/cometd-java-api-common/${cometd-java-client.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:org.cometd.java/cometd-java-api-client/${cometd-java-client.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:org.cometd.java/cometd-java-client-common/${cometd-java-client.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:org.cometd.java/cometd-java-client-http-jetty/${cometd-java-client.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:org.cometd.java/cometd-java-client-http-common/${cometd-java-client.tesb.version}</bundle>
+        <bundle dependency='true'>mvn:org.cometd.java/cometd-java-common/${cometd-java-client.tesb.version}</bundle>
         <bundle dependency='true'>mvn:org.eclipse.jetty/jetty-alpn-client/${jetty12.tesb.version}</bundle>
         <bundle dependency="true">mvn:org.eclipse.jetty/jetty-alpn-java-client/${jetty12.tesb.version}</bundle>
         <bundle dependency='true'>wrap:mvn:org.eclipse.jetty/jetty-client/${jetty12.tesb.version}$overwrite=merge&amp;Export-Package=org*;version=${jetty12.tesb.version}</bundle>
@@ -3074,7 +3076,7 @@
         <feature version='${camel-osgi-version-range}'>camel-core</feature>
         <bundle dependency='true'>mvn:commons-io/commons-io/${commons-io.tesb.version}</bundle>
         <bundle dependency='true'>mvn:org.javassist/javassist/${javassist-version}</bundle>
-        <bundle dependency='true'>wrap:mvn:org.apache.thrift/libthrift/${libthrift-version}$overwrite=merge&amp;Export-Package=org.apache.thrift*;version=${libthrift-version}</bundle>
+        <bundle dependency='true'>wrap:mvn:org.apache.thrift/libthrift/${libthrift.tesb.version}$overwrite=merge&amp;Export-Package=org.apache.thrift*;version=${libthrift.tesb.version}</bundle>
         <bundle>mvn:org.apache.camel.karaf/camel-thrift/${upstream.version}</bundle>
     </feature>
     <feature name='camel-thymeleaf' version='${upstream.version}' start-level='50'>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <!-- TODO use Karaf/Camel bom -->
     <properties>
         <upstream.version>4.8.1</upstream.version>
-        <camel-features.tesb.version>4.8.1.20260608</camel-features.tesb.version>
+        <camel-features.tesb.version>4.8.1.20260701</camel-features.tesb.version>
         <camel-support.tesb.version>4.8.1.20260120</camel-support.tesb.version>
         <camel-vm.tesb.version>4.8.1.20250320</camel-vm.tesb.version>
         <camel-activemq.tesb.version>4.8.1.20260608</camel-activemq.tesb.version>
@@ -177,6 +177,7 @@
         <activemq6.tesb.version>6.2.5</activemq6.tesb.version>
         <activemq-artemis.tesb.version>2.40.0</activemq-artemis.tesb.version>
         <angus-mail.tesb.version>2.0.4</angus-mail.tesb.version>
+        <apache-directory-api.tesb.version>2.1.8</apache-directory-api.tesb.version>
         <apache-drill.tesb.version>1.22.0</apache-drill.tesb.version>
         <asm.tesb.version>9.8</asm.tesb.version>
         <async-http-client.tesb.version>2.15.0</async-http-client.tesb.version>
@@ -187,15 +188,17 @@
         <bouncycastle.tesb.version>1.84</bouncycastle.tesb.version>
         <bytebuddy.tesb.version>1.17.6</bytebuddy.tesb.version>
         <c3p0.tesb.version>0.12.0</c3p0.tesb.version>
+        <cometd-java-client.tesb.version>8.0.12</cometd-java-client.tesb.version>
+        <cometd-java-server.tesb.version>8.0.12</cometd-java-server.tesb.version>
         <commons-beanutils.tesb.version>1.11.0</commons-beanutils.tesb.version>
-        <commons-codec.tesb.version>1.20.0</commons-codec.tesb.version>
+        <commons-codec.tesb.version>1.22.0</commons-codec.tesb.version>
         <commons-collections4.tesb.version>4.5.0</commons-collections4.tesb.version>
         <commons-compress.tesb.version>1.28.0</commons-compress.tesb.version>
-        <commons-lang3.tesb.version>3.19.0</commons-lang3.tesb.version>
+        <commons-lang3.tesb.version>3.20.0</commons-lang3.tesb.version>
         <commons-io.tesb.version>2.22.0</commons-io.tesb.version>
         <commons-pool2.tesb.version>2.13.1</commons-pool2.tesb.version>
-        <commons-text.tesb.version>1.14.0</commons-text.tesb.version>
-        <couchbase-client.tesb.version>3.11.1</couchbase-client.tesb.version>
+        <commons-text.tesb.version>1.15.0</commons-text.tesb.version>
+        <couchbase-client.tesb.version>3.12.0</couchbase-client.tesb.version>
         <curator.tesb.version>5.8.0.tesb1</curator.tesb.version>
         <djl.tesb.version>0.31.1</djl.tesb.version>
         <failureaccess.tesb.version>1.0.2</failureaccess.tesb.version>
@@ -214,8 +217,9 @@
         <httpclient.tesb.version>5.5</httpclient.tesb.version>
         <infinispan.tesb.version>15.0.11.Final</infinispan.tesb.version>
         <jackson-asl.tesb.version>1.9.16-TALEND</jackson-asl.tesb.version>
-        <jackson2.tesb.version>2.21.2</jackson2.tesb.version>
-        <jackson2-annotations.tesb.version>2.21</jackson2-annotations.tesb.version>
+        <jackson2.tesb.version>2.22.1</jackson2.tesb.version>
+        <jackson2-annotations.tesb.version>2.22</jackson2-annotations.tesb.version>
+        <jackson2-databind.tesb.version>${jackson2.tesb.version}</jackson2-databind.tesb.version>
         <jackrabbit.tesb.version>2.22.2</jackrabbit.tesb.version>
         <jakarta-el5-api.tesb.version>5.0.1</jakarta-el5-api.tesb.version>
         <jakarta-json-bind-api.tesb.version>3.0.1.tesb1</jakarta-json-bind-api.tesb.version>
@@ -244,18 +248,19 @@
         <karaf-framework.tesb.version>4.4.6.20250901</karaf-framework.tesb.version>
         <kotlin.tesb.version>2.2.20</kotlin.tesb.version>
         <kotlin-stdlib-common.tesb.version>1.9.10</kotlin-stdlib-common.tesb.version>
-        <kudu.tesb.version>1.19.0.tesb3</kudu.tesb.version>
+        <kudu.tesb.version>1.19.0.tesb4</kudu.tesb.version>
         <langchain4j.tesb.version>1.6.0</langchain4j.tesb.version>
         <langchain4j-mcp.tesb.version>1.6.0-beta12</langchain4j-mcp.tesb.version>
+        <libthrift.tesb.version>0.23.0</libthrift.tesb.version>
         <logback.tesb.version>1.5.18</logback.tesb.version>
         <lz4-java.tesb.version>1.10.3</lz4-java.tesb.version>
         <metrics.tesb.version>4.2.30</metrics.tesb.version>
         <micrometer.tesb.version>1.13.11</micrometer.tesb.version>
         <micrometer-tracing.tesb.version>1.3.9</micrometer-tracing.tesb.version>
-        <mina.tesb.version>2.2.7</mina.tesb.version>
+        <mina.tesb.version>2.2.8</mina.tesb.version>
         <minio.tesb.version>8.6.0</minio.tesb.version>
         <neethi.tesb.version>3.2.2</neethi.tesb.version>
-        <netty.tesb.version>4.1.133.Final</netty.tesb.version>
+        <netty.tesb.version>4.1.135.Final</netty.tesb.version>
         <nimbus-jose-jwt.tesb.version>10.4</nimbus-jose-jwt.tesb.version>
         <oauth2-oidc-sdk.tesb.version>11.26</oauth2-oidc-sdk.tesb.version>
         <okhttp.tesb.version>5.3.2</okhttp.tesb.version>
@@ -277,7 +282,7 @@
         <quickfixj.tesb.version>2.3.2</quickfixj.tesb.version>
         <reactor.tesb.version>3.7.8</reactor.tesb.version>
         <reactor-netty.tesb.version>1.2.8</reactor-netty.tesb.version>
-        <shiro.tesb.version>2.1.0</shiro.tesb.version>
+        <shiro.tesb.version>2.2.1</shiro.tesb.version>
         <slf4j.tesb.version>2.0.17</slf4j.tesb.version>
         <smallrye-fault-tolerance.tesb.version>6.9.0</smallrye-fault-tolerance.tesb.version>
         <snakeyaml.tesb.version>2.6</snakeyaml.tesb.version>
@@ -289,13 +294,13 @@
         <spring-security.tesb.version>6.5.10</spring-security.tesb.version>
         <spring-ws.tesb.version>4.0.12</spring-ws.tesb.version>
         <squareup-okio.tesb.version>1.17.6</squareup-okio.tesb.version>
-        <stax2-api.tesb.version>4.2.2</stax2-api.tesb.version>
+        <stax2-api.tesb.version>4.3.0</stax2-api.tesb.version>
         <thymeleaf.tesb.version>3.1.5.RELEASE</thymeleaf.tesb.version>
         <tika.tesb.version>3.2.3</tika.tesb.version>
         <typesafe-config.tesb.version>1.4.2</typesafe-config.tesb.version>
         <undertow.tesb.version>2.3.22.Final</undertow.tesb.version>
         <velocity.tesb.version>2.4.1</velocity.tesb.version>
-        <vertx.tesb.version>4.5.24</vertx.tesb.version>
+        <vertx.tesb.version>4.5.29</vertx.tesb.version>
         <wildfly-elytron.tesb.version>2.2.10.Final</wildfly-elytron.tesb.version>
         <woodstox-core.tesb.version>7.1.0</woodstox-core.tesb.version>
         <xerces-bundle.tesb.version>2.12.2.tesb2_1</xerces-bundle.tesb.version>
@@ -304,7 +309,7 @@
         <zookeeper-server.tesb.version>3.9.5.jetty12.1</zookeeper-server.tesb.version>
         <camel-osgi-cxf.tesb.version>[4.1,4.2)</camel-osgi-cxf.tesb.version>
         <camel-osgi-jetty.tesb.version>[12,13)</camel-osgi-jetty.tesb.version>
-        <camel-osgi-jackson2.tesb.version>[2.18,2.22)</camel-osgi-jackson2.tesb.version>
+        <camel-osgi-jackson2.tesb.version>[2.18,3.0)</camel-osgi-jackson2.tesb.version>
         <camel-osgi-jakarta-annotation.tesb.version>[3,4)</camel-osgi-jakarta-annotation.tesb.version>
 
         <jdk-version>17</jdk-version>
@@ -999,6 +1004,7 @@
                             <activemq6.tesb.version>${activemq6.tesb.version}</activemq6.tesb.version>
                             <activemq-artemis.tesb.version>${activemq-artemis.tesb.version}</activemq-artemis.tesb.version>
                             <angus-mail.tesb.version>${angus-mail.tesb.version}</angus-mail.tesb.version>
+                            <apache-directory-api.tesb.version>${apache-directory-api.tesb.version>}</apache-directory-api.tesb.version>
                             <apache-drill.tesb.version>${apache-drill.tesb.version>}</apache-drill.tesb.version>
                             <asm.tesb.version>${asm.tesb.version}</asm.tesb.version>
                             <async-http-client.tesb.version>${async-http-client.tesb.version}</async-http-client.tesb.version>
@@ -1009,6 +1015,8 @@
                             <bouncycastle.tesb.version>${bouncycastle.tesb.version}</bouncycastle.tesb.version>
                             <bytebuddy.tesb.version>${bytebuddy.tesb.version}</bytebuddy.tesb.version>
                             <c3p0.tesb.version>${c3p0.tesb.version}</c3p0.tesb.version>
+                            <cometd-java-client.tesb.version>${cometd-java-client.tesb.version}</cometd-java-client.tesb.version>
+                            <cometd-java-server.tesb.version>${cometd-java-server.tesb.version}</cometd-java-server.tesb.version>
                             <commons-beanutils.tesb.version>${commons-beanutils.tesb.version}</commons-beanutils.tesb.version>
                             <commons-codec.tesb.version>${commons-codec.tesb.version}</commons-codec.tesb.version>
                             <commons-collections4.tesb.version>${commons-collections4.tesb.version}</commons-collections4.tesb.version>
@@ -1038,6 +1046,7 @@
                             <jackson-asl.tesb.version>${jackson-asl.tesb.version}</jackson-asl.tesb.version>
                             <jackson2.tesb.version>${jackson2.tesb.version}</jackson2.tesb.version>
                             <jackson2-annotations.tesb.version>${jackson2-annotations.tesb.version}</jackson2-annotations.tesb.version>
+                            <jackson2-databind.tesb.version>${jackson2-databind.tesb.version}</jackson2-databind.tesb.version>
                             <jackrabbit.tesb.version>${jackrabbit.tesb.version}</jackrabbit.tesb.version>
                             <jakarta-el5-api.tesb.version>${jakarta-el5-api.tesb.version}</jakarta-el5-api.tesb.version>
                             <jakarta-json-bind-api.tesb.version>${jakarta-json-bind-api.tesb.version}</jakarta-json-bind-api.tesb.version>
@@ -1069,6 +1078,7 @@
                             <kudu.tesb.version>${kudu.tesb.version}</kudu.tesb.version>
                             <langchain4j.tesb.version>${langchain4j.tesb.version}</langchain4j.tesb.version>
                             <langchain4j-mcp.tesb.version>${langchain4j-mcp.tesb.version}</langchain4j-mcp.tesb.version>
+                            <libthrift.tesb.version>${libthrift.tesb.version}</libthrift.tesb.version>
                             <logback.tesb.version>${logback.tesb.version}</logback.tesb.version>
                             <lz4-java.tesb.version>${lz4-java.tesb.version}</lz4-java.tesb.version>
                             <metrics.tesb.version>${metrics.tesb.version}</metrics.tesb.version>


### PR DESCRIPTION
CVE-2026-54512
CVE-2026-54513
CVE-2026-54514
CVE-2026-54515
CVE-2026-54516
CVE-2026-54517
CVE-2026-54518
- jackson 2.21.2 -> 2.22.0

CVE-2026-42583
CVE-2026-44249
CVE-2026-45416
CVE-2026-50010
CVE-2026-45674
CVE-2026-47691
CVE-2026-45673
CVE-2026-45536
- netty 4.1.133.Final -> 4.1.135.Final

CVE-2026-43869 libthrift 0.20.0 -> 9.23.0

CVE-2026-49268 shiro 2.1.0 -> 2.2.1